### PR TITLE
fix(wallet-mfe): sync host state via mount snapshot subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ Thumbs.db
 
 # packages
 .npmrc
+
+# Documents & Agents
+docs/
+.claude/

--- a/src/app/mfe-contracts/wallet-mfe.types.ts
+++ b/src/app/mfe-contracts/wallet-mfe.types.ts
@@ -1,5 +1,38 @@
 import { WalletAccountChangedPayload } from './payloads';
 
+export type WalletConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'error';
+
+export type WalletConnectionSnapshot = {
+  status: WalletConnectionStatus;
+  account: string | null;
+  chainId: number | null;
+  isVerified: boolean;
+  safetyStatus: 'safe' | 'unsafe' | null;
+  isBypassed: boolean;
+  executionState: string;
+  errorCode?: string;
+  errorMessage?: string;
+};
+
+export type WalletsMfeEvent =
+  | {
+      type: 'connection.state.changed';
+      payload: { status: WalletConnectionStatus };
+    }
+  | {
+      type: 'wallet.connected';
+      payload: { account: string; chainId: number | null };
+    }
+  | { type: 'wallet.disconnected'; payload: { reason?: string } }
+  | { type: 'wallet.account.changed'; payload: { account: string } }
+  | { type: 'wallet.chain.changed'; payload: { chainId: number } }
+  | { type: 'connection.snapshot.updated'; payload: WalletConnectionSnapshot };
+
 export type WalletsMfeContext = {
   contractVersion?: '2.0.0';
   sessionId?: string;
@@ -13,6 +46,12 @@ export type WalletsMfeCallbacks = {
   onCloseRequested?: () => void;
 };
 
+export type WalletsMfeMountApi = {
+  unmount: () => void;
+  subscribe: (listener: (event: WalletsMfeEvent) => void) => () => void;
+  getSnapshot: () => WalletConnectionSnapshot;
+};
+
 export type WalletsMfeModule = {
   mount: (
     container: HTMLElement,
@@ -20,5 +59,5 @@ export type WalletsMfeModule = {
       context?: WalletsMfeContext;
       callbacks?: WalletsMfeCallbacks;
     }
-  ) => (() => void) | void;
+  ) => WalletsMfeMountApi | (() => void) | void;
 };

--- a/src/app/shared/components/wallet-bar/wallet-bar.component.ts
+++ b/src/app/shared/components/wallet-bar/wallet-bar.component.ts
@@ -19,12 +19,10 @@ export class WalletBarComponent {
     this.walletsService.account
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(account => {
-        if (account) {
-          const hadAccount = Boolean(this.account?.account);
-          this.account = account;
-          if (!hadAccount) {
-            this.isOpenWalletConnectMenu = false;
-          }
+        const hadAccount = Boolean(this.account?.account);
+        this.account = account;
+        if (account && !hadAccount) {
+          this.isOpenWalletConnectMenu = false;
         }
       });
 

--- a/src/app/shared/mfe/wallets/wallets.component.ts
+++ b/src/app/shared/mfe/wallets/wallets.component.ts
@@ -4,10 +4,15 @@ import {
   ElementRef,
   AfterViewInit,
   OnDestroy,
+  NgZone,
 } from '@angular/core';
 import { loadRemoteModule } from '@angular-architects/module-federation';
 import { WalletsService } from '@shared/mfe/wallets/wallets.service';
-import { WalletsMfeModule } from '@mfe-contracts/wallet-mfe.types';
+import {
+  WalletConnectionSnapshot,
+  WalletsMfeModule,
+  WalletsMfeMountApi,
+} from '@mfe-contracts/wallet-mfe.types';
 import { WalletAccountChangedPayload } from '@mfe-contracts/payloads';
 import { AppLoggerService } from '@core/logging/app-logger.service';
 
@@ -21,11 +26,13 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
   public containerRef!: ElementRef<HTMLElement>;
 
   private unmountMfe: (() => void) | undefined;
+  private unsubscribeEvents: (() => void) | undefined;
   private isDestroyed = false;
 
   constructor(
     private walletsService: WalletsService,
-    private logger: AppLoggerService
+    private logger: AppLoggerService,
+    private ngZone: NgZone
   ) {}
 
   ngAfterViewInit() {
@@ -59,21 +66,44 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
         throw new Error('MFE mount function is not available');
       }
 
-      const unmount = mfeModule.mount(container, {
+      const mountResult = mfeModule.mount(container, {
         context: {
           contractVersion: '2.0.0',
           environment: 'dev',
         },
         callbacks: {
           onAccountChanged: (account: WalletAccountChangedPayload) => {
-            this.walletsService.setAccount(account);
+            this.ngZone.run(() => {
+              this.walletsService.setAccount(account);
+            });
           },
           onCloseRequested: () => {
-            this.walletsService.requestClose();
+            this.ngZone.run(() => {
+              this.walletsService.requestClose();
+            });
           },
         },
       });
-      this.unmountMfe = typeof unmount === 'function' ? unmount : undefined;
+      this.unsubscribeEvents?.();
+      this.unsubscribeEvents = undefined;
+
+      if (this.isMountApi(mountResult)) {
+        this.unmountMfe = mountResult.unmount;
+        this.ngZone.run(() => {
+          this.applyConnectionSnapshot(mountResult.getSnapshot());
+        });
+        this.unsubscribeEvents = mountResult.subscribe(event => {
+          if (event.type === 'connection.snapshot.updated') {
+            this.ngZone.run(() => {
+              this.applyConnectionSnapshot(event.payload);
+            });
+          }
+        });
+      } else {
+        this.unmountMfe =
+          typeof mountResult === 'function' ? mountResult : undefined;
+      }
+
       this.logger.log('info', 'Wallets MFE: mounted successfully');
     } catch (error) {
       container.innerHTML =
@@ -84,8 +114,29 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  private applyConnectionSnapshot(snapshot: WalletConnectionSnapshot): void {
+    if (snapshot.account) {
+      this.walletsService.setAccount({ account: snapshot.account });
+      return;
+    }
+
+    this.walletsService.setAccount(undefined);
+  }
+
+  private isMountApi(value: unknown): value is WalletsMfeMountApi {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'unmount' in value &&
+      'subscribe' in value &&
+      'getSnapshot' in value
+    );
+  }
+
   ngOnDestroy(): void {
     this.isDestroyed = true;
+    this.unsubscribeEvents?.();
+    this.unsubscribeEvents = undefined;
     this.unmountMfe?.();
     this.unmountMfe = undefined;
   }

--- a/src/app/shared/mfe/wallets/wallets.service.ts
+++ b/src/app/shared/mfe/wallets/wallets.service.ts
@@ -10,7 +10,7 @@ export class WalletsService {
   public account = new BehaviorSubject<WalletAccount | undefined>(undefined);
   public closeRequested = new BehaviorSubject<boolean>(false);
 
-  setAccount(account: WalletAccount): void {
+  setAccount(account: WalletAccount | undefined): void {
     this.account.next(account);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes host ↔ wallet MFE session synchronization so wallet state is reflected immediately on app load and UI updates do not wait for an extra user click.

### What changed

- Updated host wallet MFE integration to consume modern mount API:
  - uses `getSnapshot()` right after mount
  - subscribes to `connection.snapshot.updated` events
- Ensured MFE-driven callbacks/events run inside Angular change detection (`NgZone`)
  - fixes delayed UI refresh where wallet address appeared only after another click
- Extended host MFE contract typings to match current MFE API surface
  - added snapshot/event/mount API types
- Improved host wallet state handling
  - account can now be cleared (`undefined`) and disconnect state is reflected correctly
- Included repo hygiene update in `.gitignore` (`docs/`, `.claude/`)