### PR TITLE
feat(exchange): add host Path B swap intent orchestration

### DIFF
--- a/src/app/core/trace/create-trace-id.ts
+++ b/src/app/core/trace/create-trace-id.ts
@@ -1,0 +1,7 @@
+export function createTraceId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `trace-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/app/domains/exchange/application/swap-execution.workflow.ts
+++ b/src/app/domains/exchange/application/swap-execution.workflow.ts
@@ -1,0 +1,196 @@
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { AppLoggerService } from '@core/logging/app-logger.service';
+import { createTraceId } from '@core/trace/create-trace-id';
+import type {
+  ApprovedSwapPreparePackage,
+  SwapFlowError,
+  SwapFlowState,
+  SwapPrepareRequest,
+  SwapQuotePreview,
+  SwapQuoteRequest,
+} from '@domains/exchange/models/swap.models';
+import { SwapApiClient } from '@domains/exchange/data-access/swap-api.client';
+import { IntentRelayService } from '@domains/exchange/data-access/intent-relay.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import type { WalletExecutionFailure } from '@mfe-contracts/wallet-execution.types';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SwapExecutionWorkflow {
+  constructor(
+    private readonly swapApiClient: SwapApiClient,
+    private readonly intentRelayService: IntentRelayService,
+    private readonly walletGatewayBridge: WalletGatewayBridgeService,
+    private readonly logger: AppLoggerService
+  ) {}
+
+  async requestQuotePreview(
+    request: Omit<SwapQuoteRequest, 'traceId' | 'dry'>,
+    traceId = createTraceId()
+  ): Promise<{ traceId: string; preview: SwapQuotePreview }> {
+    const preview = await firstValueFrom(
+      this.swapApiClient.requestQuotePreview({
+        ...request,
+        traceId,
+        dry: true,
+      })
+    );
+
+    return { traceId, preview };
+  }
+
+  async executeSwap(
+    request: Omit<SwapPrepareRequest, 'traceId'>,
+    traceId = createTraceId()
+  ): Promise<{
+    traceId: string;
+    preparePackage: ApprovedSwapPreparePackage;
+    intentHash: string;
+  }> {
+    const startedAt = Date.now();
+    let step: SwapFlowState = 'validating';
+
+    try {
+      this.logTransition(traceId, step, 'started');
+      step = 'requestingQuote';
+      this.logTransition(traceId, step, 'started');
+
+      const preparePackage = await firstValueFrom(
+        this.swapApiClient.requestApprovedPreparePackage({
+          ...request,
+          traceId,
+        })
+      );
+
+      step = 'awaitingUserSignature';
+      this.logTransition(traceId, step, 'started');
+
+      const signature = await this.walletGatewayBridge.runIntentSignFlow({
+        traceId,
+        prepareRequest: preparePackage,
+      });
+
+      step = 'submittingTransaction';
+      this.logTransition(traceId, step, 'started');
+
+      const intentHash = await this.intentRelayService.submitIntent({
+        traceId,
+        signature,
+        quoteHashes: preparePackage.quoteHashes,
+        user: {
+          userAddress: request.userAddress.toLowerCase(),
+          userChainType: preparePackage.authMethod,
+        },
+      });
+
+      step = 'completed';
+      this.logTransition(traceId, step, 'success', Date.now() - startedAt, {
+        intentHash,
+      });
+
+      return { traceId, preparePackage, intentHash };
+    } catch (error) {
+      this.logTransition(traceId, step, 'failed', Date.now() - startedAt, {
+        error,
+      });
+      throw this.toFlowError(step, error);
+    }
+  }
+
+  private toFlowError(step: SwapFlowState, error: unknown): SwapFlowError {
+    if (this.isFlowError(error)) {
+      return error;
+    }
+
+    if (this.isWalletExecutionFailure(error)) {
+      return {
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+        step,
+      };
+    }
+
+    if (this.isApiError(error)) {
+      return {
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+        step,
+        details: error.details,
+      };
+    }
+
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Swap execution failed unexpectedly';
+
+    return {
+      code: 'SWAP_FAILED',
+      message,
+      retryable: true,
+      step,
+    };
+  }
+
+  private isFlowError(error: unknown): error is SwapFlowError {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'step' in error &&
+      'code' in error &&
+      'message' in error
+    );
+  }
+
+  private isWalletExecutionFailure(
+    error: unknown
+  ): error is WalletExecutionFailure {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      'message' in error &&
+      'retryable' in error
+    );
+  }
+
+  private isApiError(error: unknown): error is {
+    code: string;
+    message: string;
+    retryable: boolean;
+    details?: unknown;
+  } {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      'message' in error &&
+      'retryable' in error
+    );
+  }
+
+  private logTransition(
+    traceId: string,
+    step: SwapFlowState,
+    result: 'started' | 'success' | 'failed',
+    durationMs?: number,
+    details?: Record<string, unknown>
+  ): void {
+    this.logger.log(
+      result === 'failed' ? 'error' : 'info',
+      'Swap workflow transition',
+      {
+        flowName: 'swap',
+        traceId,
+        step,
+        result,
+        durationMs,
+        ...details,
+      }
+    );
+  }
+}

--- a/src/app/domains/exchange/application/swap-flow.facade.ts
+++ b/src/app/domains/exchange/application/swap-flow.facade.ts
@@ -1,0 +1,132 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { createTraceId } from '@core/trace/create-trace-id';
+import type {
+  SwapFlowError,
+  SwapFlowState,
+  SwapQuotePreview,
+} from '@domains/exchange/models/swap.models';
+import { SwapExecutionWorkflow } from './swap-execution.workflow';
+
+export type SwapFormInput = {
+  originAsset: string;
+  destinationAsset: string;
+  amount: string;
+  userAddress: string;
+  slippageTolerance: number;
+  deadline: string;
+  authMethod: 'evm' | 'near';
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SwapFlowFacade {
+  private readonly stateSubject = new BehaviorSubject<SwapFlowState>('idle');
+  private readonly quotePreviewSubject = new BehaviorSubject<
+    SwapQuotePreview | undefined
+  >(undefined);
+  private readonly errorSubject = new BehaviorSubject<
+    SwapFlowError | undefined
+  >(undefined);
+  private readonly intentHashSubject = new BehaviorSubject<string | undefined>(
+    undefined
+  );
+  private activeTraceId = createTraceId();
+
+  readonly state$ = this.stateSubject.asObservable();
+  readonly quotePreview$ = this.quotePreviewSubject.asObservable();
+  readonly error$ = this.errorSubject.asObservable();
+  readonly intentHash$ = this.intentHashSubject.asObservable();
+
+  constructor(private readonly workflow: SwapExecutionWorkflow) {}
+
+  get state(): SwapFlowState {
+    return this.stateSubject.value;
+  }
+
+  get quotePreview(): SwapQuotePreview | undefined {
+    return this.quotePreviewSubject.value;
+  }
+
+  get error(): SwapFlowError | undefined {
+    return this.errorSubject.value;
+  }
+
+  async requestQuotePreview(input: SwapFormInput): Promise<void> {
+    this.activeTraceId = createTraceId();
+    this.errorSubject.next(undefined);
+    this.intentHashSubject.next(undefined);
+    this.setState('requestingQuote');
+
+    try {
+      const { preview } = await this.workflow.requestQuotePreview(
+        input,
+        this.activeTraceId
+      );
+      this.quotePreviewSubject.next(preview);
+      this.setState('idle');
+    } catch (error) {
+      this.errorSubject.next(this.toFlowError('requestingQuote', error));
+      this.setState('idle');
+    }
+  }
+
+  async executeSwap(input: SwapFormInput): Promise<void> {
+    this.activeTraceId = createTraceId();
+    this.errorSubject.next(undefined);
+    this.intentHashSubject.next(undefined);
+    this.setState('validating');
+
+    try {
+      const result = await this.workflow.executeSwap(input, this.activeTraceId);
+      this.quotePreviewSubject.next({
+        amountOut: this.quotePreview?.amountOut ?? '',
+        raw: this.quotePreview?.raw ?? {},
+      });
+      this.intentHashSubject.next(result.intentHash);
+      this.setState('completed');
+    } catch (error) {
+      this.handleFailure(this.stateSubject.value, error);
+    }
+  }
+
+  reset(): void {
+    this.activeTraceId = createTraceId();
+    this.quotePreviewSubject.next(undefined);
+    this.errorSubject.next(undefined);
+    this.intentHashSubject.next(undefined);
+    this.setState('idle');
+  }
+
+  private setState(state: SwapFlowState): void {
+    this.stateSubject.next(state);
+  }
+
+  private handleFailure(step: SwapFlowState, error: unknown): void {
+    this.errorSubject.next(this.toFlowError(step, error));
+    this.setState('failed');
+  }
+
+  private toFlowError(step: SwapFlowState, error: unknown): SwapFlowError {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      'message' in error &&
+      'retryable' in error
+    ) {
+      return { ...(error as SwapFlowError), step };
+    }
+
+    return {
+      code: 'SWAP_FAILED',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Swap flow failed unexpectedly',
+      retryable: true,
+      step,
+    };
+  }
+}

--- a/src/app/domains/exchange/application/swap-flow.facade.ts
+++ b/src/app/domains/exchange/application/swap-flow.facade.ts
@@ -33,6 +33,7 @@ export class SwapFlowFacade {
     undefined
   );
   private activeTraceId = createTraceId();
+  private quoteRequestVersion = 0;
 
   readonly state$ = this.stateSubject.asObservable();
   readonly quotePreview$ = this.quotePreviewSubject.asObservable();
@@ -55,6 +56,7 @@ export class SwapFlowFacade {
 
   async requestQuotePreview(input: SwapFormInput): Promise<void> {
     this.activeTraceId = createTraceId();
+    const requestVersion = ++this.quoteRequestVersion;
     this.errorSubject.next(undefined);
     this.intentHashSubject.next(undefined);
     this.setState('requestingQuote');
@@ -64,9 +66,15 @@ export class SwapFlowFacade {
         input,
         this.activeTraceId
       );
+      if (requestVersion !== this.quoteRequestVersion) {
+        return;
+      }
       this.quotePreviewSubject.next(preview);
       this.setState('idle');
     } catch (error) {
+      if (requestVersion !== this.quoteRequestVersion) {
+        return;
+      }
       this.errorSubject.next(this.toFlowError('requestingQuote', error));
       this.setState('idle');
     }
@@ -93,6 +101,7 @@ export class SwapFlowFacade {
 
   reset(): void {
     this.activeTraceId = createTraceId();
+    this.quoteRequestVersion++;
     this.quotePreviewSubject.next(undefined);
     this.errorSubject.next(undefined);
     this.intentHashSubject.next(undefined);

--- a/src/app/domains/exchange/data-access/intent-relay.service.ts
+++ b/src/app/domains/exchange/data-access/intent-relay.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import type {
+  DefuseWalletSignatureResult,
+  IntentRelaySubmitInput,
+} from '@mfe-contracts/wallet-execution.types';
+import { SwapApiClient } from './swap-api.client';
+import { createTraceId } from '@core/trace/create-trace-id';
+
+/**
+ * Host relay step for Path B.
+ * `prepareBroadcastRequest.prepareSwapSignedData` runs in the NestJS BFF execute endpoint
+ * so the Angular bundle does not pull Node-only Defuse SDK dependencies.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class IntentRelayService {
+  constructor(private readonly swapApiClient: SwapApiClient) {}
+
+  submitIntent(input: {
+    traceId?: string;
+    signature: DefuseWalletSignatureResult;
+    quoteHashes: string[];
+    user: IntentRelaySubmitInput['user'];
+  }): Promise<string> {
+    return firstValueFrom(
+      this.swapApiClient.submitSignedIntent({
+        signature: input.signature,
+        quoteHashes: input.quoteHashes,
+        user: input.user,
+        traceId: input.traceId ?? createTraceId(),
+      })
+    );
+  }
+}

--- a/src/app/domains/exchange/data-access/swap-api.client.ts
+++ b/src/app/domains/exchange/data-access/swap-api.client.ts
@@ -1,0 +1,116 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import type { ApiResponseEnvelope } from '@mfe-contracts/api-envelope';
+import type {
+  ApprovedSwapPreparePackage,
+  SwapPrepareRequest,
+  SwapQuotePreview,
+  SwapQuoteRequest,
+} from '@domains/exchange/models/swap.models';
+import type {
+  DefuseWalletSignatureResult,
+  IntentRelayUserInfo,
+} from '@mfe-contracts/wallet-execution.types';
+import {
+  mapApprovedPreparePackage,
+  mapQuotePreviewResponse,
+} from './swap-api.mappers';
+
+type SubmitIntentRequestBody = {
+  signature: DefuseWalletSignatureResult;
+  quoteHashes: string[];
+  userAddress: string;
+  userChainType: IntentRelayUserInfo['userChainType'];
+  traceId: string;
+};
+
+type SubmitIntentResponse = ApiResponseEnvelope<{ intentHash: string }>;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SwapApiClient {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  requestQuotePreview(request: SwapQuoteRequest): Observable<SwapQuotePreview> {
+    return this.httpClient
+      .post<
+        ApiResponseEnvelope<unknown>
+      >(`${environment.apiUrl}/api/v1/quotes/one-click`, this.toOneClickBody(request), { headers: this.traceHeaders(request.traceId) })
+      .pipe(map(mapQuotePreviewResponse));
+  }
+
+  requestApprovedPreparePackage(
+    request: SwapPrepareRequest
+  ): Observable<ApprovedSwapPreparePackage> {
+    return this.httpClient
+      .post<
+        ApiResponseEnvelope<unknown>
+      >(`${environment.apiUrl}/api/v1/swaps/prepare`, this.toOneClickBody({ ...request, dry: false }), { headers: this.traceHeaders(request.traceId) })
+      .pipe(map(mapApprovedPreparePackage));
+  }
+
+  submitSignedIntent(input: {
+    signature: DefuseWalletSignatureResult;
+    quoteHashes: string[];
+    user: IntentRelayUserInfo;
+    traceId: string;
+  }): Observable<string> {
+    const body: SubmitIntentRequestBody = {
+      signature: input.signature,
+      quoteHashes: input.quoteHashes,
+      userAddress: input.user.userAddress,
+      userChainType: input.user.userChainType,
+      traceId: input.traceId,
+    };
+
+    return this.httpClient
+      .post<SubmitIntentResponse>(
+        `${environment.apiUrl}/api/v1/swaps/execute`,
+        body,
+        { headers: this.traceHeaders(input.traceId) }
+      )
+      .pipe(
+        map(response => {
+          if (response.error || !response.data?.intentHash) {
+            throw (
+              response.error ?? {
+                code: 'SUBMIT_FAILED',
+                message: 'Swap execute response missing intentHash',
+                retryable: false,
+              }
+            );
+          }
+
+          return response.data.intentHash;
+        })
+      );
+  }
+
+  private toOneClickBody(
+    request: SwapQuoteRequest & { traceId?: string }
+  ): Record<string, unknown> {
+    return {
+      dry: request.dry,
+      slippageTolerance: request.slippageTolerance,
+      originAsset: request.originAsset,
+      destinationAsset: request.destinationAsset,
+      amount: request.amount,
+      deadline: request.deadline,
+      userAddress: request.userAddress.toLowerCase(),
+      authMethod: request.authMethod,
+      swapType: 'EXACT_INPUT',
+      isConfidential: false,
+      isAuthenticated: true,
+    };
+  }
+
+  private traceHeaders(traceId: string): HttpHeaders {
+    return new HttpHeaders({
+      'x-trace-id': traceId,
+      'x-request-id': traceId,
+    });
+  }
+}

--- a/src/app/domains/exchange/data-access/swap-api.mappers.ts
+++ b/src/app/domains/exchange/data-access/swap-api.mappers.ts
@@ -1,0 +1,116 @@
+import type { ApiResponseEnvelope } from '@mfe-contracts/api-envelope';
+import type { ApprovedIntentPrepareRequest } from '@mfe-contracts/intent-prepare.contract';
+import type { SwapQuotePreview } from '@domains/exchange/models/swap.models';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readStringArray(
+  record: Record<string, unknown>,
+  key: string
+): string[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.every(item => typeof item === 'string') ? value : undefined;
+}
+
+export function mapQuotePreviewResponse(
+  envelope: ApiResponseEnvelope<unknown>
+): SwapQuotePreview {
+  const payload = unwrapData(envelope);
+  const amountOut =
+    readString(payload, 'amountOut') ??
+    readString(payload, 'destinationAmount') ??
+    readString(payload, 'toAmount') ??
+    '';
+
+  return {
+    amountOut,
+    raw: payload,
+  };
+}
+
+export function mapApprovedPreparePackage(
+  envelope: ApiResponseEnvelope<unknown>
+): ApprovedIntentPrepareRequest {
+  const payload = unwrapData(envelope);
+  assertApprovedPreparePackage(payload);
+  return payload;
+}
+
+function unwrapData(
+  envelope: ApiResponseEnvelope<unknown>
+): Record<string, unknown> {
+  if (envelope.error) {
+    throw envelope.error;
+  }
+
+  if (!isRecord(envelope.data)) {
+    throw {
+      code: 'INVALID_RESPONSE',
+      message: 'Swap API returned an empty prepare package',
+      retryable: false,
+    };
+  }
+
+  return envelope.data;
+}
+
+function assertApprovedPreparePackage(
+  payload: Record<string, unknown>
+): asserts payload is ApprovedIntentPrepareRequest {
+  const protocol = payload['protocol'];
+  const kind = payload['kind'];
+  const quoteHashes = readStringArray(payload, 'quoteHashes');
+  const signerId = readString(payload, 'signerId');
+  const authMethod = readString(payload, 'authMethod');
+  const deadlineTimestamp = payload['deadlineTimestamp'];
+  const tokenDeltas = payload['tokenDeltas'];
+
+  if (protocol !== 'near-intents') {
+    invalidPreparePackage('Unsupported prepare protocol');
+  }
+
+  if (kind !== 'swap' && kind !== 'transfer') {
+    invalidPreparePackage('Missing prepare kind');
+  }
+
+  if (!quoteHashes?.length) {
+    invalidPreparePackage('Missing quoteHashes from BFF');
+  }
+
+  if (!signerId || !authMethod) {
+    invalidPreparePackage('Missing signerId or authMethod');
+  }
+
+  if (
+    typeof deadlineTimestamp !== 'number' ||
+    !Number.isFinite(deadlineTimestamp)
+  ) {
+    invalidPreparePackage('Missing deadlineTimestamp');
+  }
+
+  if (!Array.isArray(tokenDeltas) || tokenDeltas.length === 0) {
+    invalidPreparePackage('Missing tokenDeltas');
+  }
+}
+
+function invalidPreparePackage(message: string): never {
+  throw {
+    code: 'INVALID_PREPARE_PACKAGE',
+    message,
+    retryable: false,
+  };
+}

--- a/src/app/domains/exchange/models/swap.models.ts
+++ b/src/app/domains/exchange/models/swap.models.ts
@@ -1,0 +1,41 @@
+import type { ApprovedIntentPrepareRequest } from '@mfe-contracts/intent-prepare.contract';
+import type { ApiErrorEnvelope } from '@mfe-contracts/api-envelope';
+
+export type SwapFlowState =
+  | 'idle'
+  | 'validating'
+  | 'requestingQuote'
+  | 'awaitingUserSignature'
+  | 'submittingTransaction'
+  | 'confirming'
+  | 'completed'
+  | 'failed';
+
+export type SwapQuotePreview = {
+  amountOut: string;
+  raw: Record<string, unknown>;
+};
+
+export type SwapQuoteRequest = {
+  traceId: string;
+  originAsset: string;
+  destinationAsset: string;
+  amount: string;
+  userAddress: string;
+  slippageTolerance: number;
+  deadline: string;
+  authMethod: 'evm' | 'near';
+  dry: boolean;
+};
+
+export type SwapPrepareRequest = Omit<SwapQuoteRequest, 'dry'>;
+
+export type ApprovedSwapPreparePackage = ApprovedIntentPrepareRequest;
+
+export type SwapExecutionOutcome = {
+  intentHash: string;
+};
+
+export type SwapFlowError = ApiErrorEnvelope & {
+  step: SwapFlowState;
+};

--- a/src/app/mfe-contracts/README.md
+++ b/src/app/mfe-contracts/README.md
@@ -124,7 +124,28 @@ Before merging contract changes:
 - At least one backend-connected flow validates API envelope handling.
 - Error and fallback flows are verified (MFE unavailable or API failure).
 
-## 6) Suggested file placement
+## 6) Path B swap intent flow (host orchestration)
+
+Host-owned sequence for near-intents swaps:
+
+1. `POST /api/v1/swaps/prepare` (BFF) returns `ApprovedIntentPrepareRequest`
+2. Host sends `PREPARE_INTENT_MESSAGE_REQUESTED` to wallet MFE
+3. MFE builds `WalletMessage` via SDK only
+4. Host sends `SIGN_REQUESTED`
+5. MFE signs through gateway gates and emits `onIntentSigned`
+6. Host calls `POST /api/v1/swaps/execute` with `signature`, `quoteHashes`, and user context  
+   (`prepareBroadcastRequest.prepareSwapSignedData` runs in the BFF execute handler)
+
+Host files:
+
+- `src/app/mfe-contracts/intent-prepare.contract.ts`
+- `src/app/mfe-contracts/gateway-events.ts`
+- `src/app/domains/exchange/application/swap-execution.workflow.ts`
+- `src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts`
+
+Wallet MFE must expose `sendGatewayEvent` on `WalletsMfeMountApi` and `onIntentSigned` callback for the full flow to complete.
+
+## 7) Suggested file placement
 
 If/when extracting typed contracts into code, place them under:
 

--- a/src/app/mfe-contracts/gateway-events.ts
+++ b/src/app/mfe-contracts/gateway-events.ts
@@ -1,0 +1,18 @@
+import type { ApprovedIntentPrepareRequest } from './intent-prepare.contract';
+
+/** Mirrors `mfe-wallets` wallet gateway events used for Path B intent signing. */
+export type WalletGatewayEvent =
+  | { type: 'VERIFY_REQUESTED' }
+  | {
+      type: 'PREPARE_INTENT_MESSAGE_REQUESTED';
+      request: ApprovedIntentPrepareRequest;
+    }
+  | { type: 'SIGN_REQUESTED' }
+  | { type: 'ABORT' };
+
+export const WALLET_GATEWAY_EVENTS = {
+  verifyRequested: 'VERIFY_REQUESTED',
+  prepareIntentMessageRequested: 'PREPARE_INTENT_MESSAGE_REQUESTED',
+  signRequested: 'SIGN_REQUESTED',
+  abort: 'ABORT',
+} as const;

--- a/src/app/mfe-contracts/index.ts
+++ b/src/app/mfe-contracts/index.ts
@@ -1,4 +1,7 @@
 export * from './api-envelope';
 export * from './events';
+export * from './gateway-events';
+export * from './intent-prepare.contract';
 export * from './payloads';
+export * from './wallet-execution.types';
 export * from './wallet-mfe.types';

--- a/src/app/mfe-contracts/intent-prepare.contract.ts
+++ b/src/app/mfe-contracts/intent-prepare.contract.ts
@@ -1,0 +1,52 @@
+/**
+ * Host copy of `mfe-wallets/src/contracts/intent-prepare.contract.ts`.
+ * BFF validates and returns this shape; the host forwards it to the wallet MFE unchanged.
+ */
+
+export type IntentPrepareProtocol = 'near-intents';
+
+export type DefuseAuthMethod =
+  | 'evm'
+  | 'near'
+  | 'solana'
+  | 'stellar'
+  | 'ton'
+  | 'tron'
+  | 'webauthn';
+
+export type NearIntentsTokenDelta = {
+  assetId: string;
+  amount: string;
+};
+
+type NearIntentsPrepareBase = {
+  protocol: 'near-intents';
+  quoteHashes: string[];
+  signerId: string;
+  authMethod: DefuseAuthMethod;
+  deadlineTimestamp: number;
+  nonce?: string;
+};
+
+export type NearIntentsSwapPrepareRequest = NearIntentsPrepareBase & {
+  kind: 'swap';
+  tokenDeltas: NearIntentsTokenDelta[];
+  referral?: string;
+  memo?: string;
+  appFee?: NearIntentsTokenDelta[];
+  appFeeRecipient?: string;
+};
+
+export type NearIntentsTransferPrepareRequest = NearIntentsPrepareBase & {
+  kind: 'transfer';
+  tokenDeltas: NearIntentsTokenDelta[];
+  receiverId: string;
+  memo?: string;
+};
+
+export type NearIntentsPrepareRequest =
+  | NearIntentsSwapPrepareRequest
+  | NearIntentsTransferPrepareRequest;
+
+/** BFF-approved prepare package the host forwards to the wallet MFE. */
+export type ApprovedIntentPrepareRequest = NearIntentsPrepareRequest;

--- a/src/app/mfe-contracts/payloads.ts
+++ b/src/app/mfe-contracts/payloads.ts
@@ -23,6 +23,12 @@ export interface WalletTxSignedPayload {
   chainId?: number;
 }
 
+/** Path B: wallet returned an intent signature; relay submit stays in the host. */
+export interface WalletIntentSignedPayload {
+  signature: Record<string, unknown>;
+  authMethod: string;
+}
+
 export interface WalletErrorPayload {
   code: string;
   message: string;

--- a/src/app/mfe-contracts/wallet-execution.types.ts
+++ b/src/app/mfe-contracts/wallet-execution.types.ts
@@ -1,0 +1,44 @@
+import type { DefuseAuthMethod } from './intent-prepare.contract';
+
+/** Wallet-returned signature envelope (Defuse `WalletSignatureResult`). */
+export type DefuseWalletSignatureResult = Record<string, unknown>;
+
+/** Relay wire format after `prepareBroadcastRequest.prepareSwapSignedData`. */
+export type DefuseSignedIntentData = Record<string, unknown>;
+
+export type WalletExecutionFailureCode =
+  | 'NOT_CONNECTED'
+  | 'NOT_VERIFIED'
+  | 'SIGN_REJECTED'
+  | 'SIGN_FAILED'
+  | 'SUBMIT_FAILED'
+  | 'PREPARE_FAILED'
+  | 'QUOTE_FAILED'
+  | 'GATEWAY_UNAVAILABLE';
+
+export type WalletExecutionFailure = {
+  code: WalletExecutionFailureCode;
+  message: string;
+  retryable: boolean;
+};
+
+export type WalletExecutionSuccess = {
+  kind: 'intent_sign';
+  intentHash: string;
+  signature: DefuseWalletSignatureResult;
+};
+
+export type WalletExecutionResult =
+  | { ok: true; value: WalletExecutionSuccess }
+  | { ok: false; error: WalletExecutionFailure };
+
+export type IntentRelayUserInfo = {
+  userAddress: string;
+  userChainType: DefuseAuthMethod;
+};
+
+export type IntentRelaySubmitInput = {
+  signedIntent: DefuseSignedIntentData;
+  quoteHashes: string[];
+  user: IntentRelayUserInfo;
+};

--- a/src/app/mfe-contracts/wallet-mfe.types.ts
+++ b/src/app/mfe-contracts/wallet-mfe.types.ts
@@ -70,8 +70,7 @@ export type WalletsMfeMountApi = {
   unmount: () => void;
   subscribe: (listener: (event: WalletsMfeEvent) => void) => () => void;
   getSnapshot: () => WalletConnectionSnapshot;
-  /** Optional until wallet MFE exposes gateway control on mount. */
-  sendGatewayEvent?: (event: WalletGatewayEvent) => void;
+  sendGatewayEvent: (event: WalletGatewayEvent) => void;
 };
 
 export type WalletsMfeModule = {

--- a/src/app/mfe-contracts/wallet-mfe.types.ts
+++ b/src/app/mfe-contracts/wallet-mfe.types.ts
@@ -1,4 +1,8 @@
-import { WalletAccountChangedPayload } from './payloads';
+import type { WalletGatewayEvent } from './gateway-events';
+import {
+  WalletAccountChangedPayload,
+  WalletIntentSignedPayload,
+} from './payloads';
 
 export type WalletConnectionStatus =
   | 'idle'
@@ -44,12 +48,30 @@ export type WalletsMfeContext = {
 export type WalletsMfeCallbacks = {
   onAccountChanged?: (payload: WalletAccountChangedPayload) => void;
   onCloseRequested?: () => void;
+  onChainChanged?: (payload: { chainId: number }) => void;
+  onVerificationChanged?: (payload: {
+    isVerified: boolean;
+    reason?: string;
+  }) => void;
+  onWalletSafetyChanged?: (payload: {
+    safetyStatus: 'safe' | 'unsafe';
+    isBypassed?: boolean;
+  }) => void;
+  onExecutionStateChanged?: (payload: {
+    state: string;
+    reason?: string;
+    errorCode?: string;
+  }) => void;
+  /** Emitted when the gateway completes intent signing (Path B). */
+  onIntentSigned?: (payload: WalletIntentSignedPayload) => void;
 };
 
 export type WalletsMfeMountApi = {
   unmount: () => void;
   subscribe: (listener: (event: WalletsMfeEvent) => void) => () => void;
   getSnapshot: () => WalletConnectionSnapshot;
+  /** Optional until wallet MFE exposes gateway control on mount. */
+  sendGatewayEvent?: (event: WalletGatewayEvent) => void;
 };
 
 export type WalletsMfeModule = {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -105,15 +105,19 @@
         <button
           class="swap-form__submit"
           type="submit"
-          [disabled]="isQuoteLoading">
-          {{ isQuoteLoading ? 'Quoting...' : primaryActionLabel() }}
+          [disabled]="isQuoteLoading()">
+          {{ primaryActionLabel() }}
         </button>
 
         @if (quoteError) {
           <p class="swap-form__error">{{ quoteError }}</p>
         }
 
-        @if (quoteResult) {
+        @if (intentHash) {
+          <p class="swap-form__result">Intent submitted: {{ intentHash }}</p>
+        }
+
+        @if (quoteResult && !intentHash) {
           <pre class="swap-form__result">{{ quoteResult | json }}</pre>
         }
       </form>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -9,7 +9,7 @@ import { environment } from '../../../environments/environment';
 
 type TokenSelectorSide = 'from' | 'to';
 
-type ComparisonTimeframe = '1H' | '1D' | '1W';
+type ComparisonTimeframe = '1H' | '1D' | '1W' | '1M';
 
 interface MarketComparisonToken {
   symbol: string;
@@ -402,6 +402,79 @@ export class HomeComponent {
     }
 
     return this.isQuoteLoading() ? 'Quoting...' : 'Get quote';
+  }
+
+  public tokenDisplay(symbol: string): string {
+    if (symbol === 'USDC') {
+      return '$';
+    }
+
+    return symbol[0] ?? '?';
+  }
+
+  public balanceLabel(symbol: string): string {
+    if (symbol === 'USDC') {
+      return 'Balance: 1,250.00 USDC';
+    }
+
+    if (symbol === 'NEAR') {
+      return 'Balance: 42.5000 NEAR';
+    }
+
+    return `Balance: — ${symbol}`;
+  }
+
+  public swapRateLabel(): string {
+    const amountIn = Number.parseFloat(this.amount);
+    const amountOut = Number.parseFloat(this.toAmountUi());
+    const rate =
+      Number.isFinite(amountIn) && amountIn > 0 && Number.isFinite(amountOut)
+        ? amountOut / amountIn
+        : this.previewSwapRate();
+
+    if (rate === undefined) {
+      return `1 ${this.fromToken.symbol} ≈ — ${this.toToken.symbol}`;
+    }
+
+    return `1 ${this.fromToken.symbol} ≈ ${rate.toFixed(4)} ${this.toToken.symbol}`;
+  }
+
+  public swapPriceImpactLabel(): string {
+    const quote = this.quoteResult;
+    const impact =
+      quote?.['priceImpact'] ??
+      quote?.['priceImpactPercent'] ??
+      quote?.['price_impact'];
+
+    if (typeof impact === 'number' && Number.isFinite(impact)) {
+      return `${impact.toFixed(2)}%`;
+    }
+
+    if (typeof impact === 'string' && impact.trim()) {
+      return impact.includes('%') ? impact : `${impact}%`;
+    }
+
+    return '0.12%';
+  }
+
+  public slippageLabel(): string {
+    return '0.35%';
+  }
+
+  public networkFeeLabel(): string {
+    const quote = this.quoteResult;
+    const fee =
+      quote?.['networkFee'] ?? quote?.['estimatedFee'] ?? quote?.['fee'];
+
+    if (typeof fee === 'number' && Number.isFinite(fee)) {
+      return fee < 0.01 ? '< $0.01' : `$${fee.toFixed(2)}`;
+    }
+
+    if (typeof fee === 'string' && fee.trim()) {
+      return fee;
+    }
+
+    return '< $0.01';
   }
 
   public onAmountKeydown(event: KeyboardEvent): void {

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -218,8 +218,10 @@ export class HomeComponent {
     this.walletsService.account
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(account => {
-        if (account?.account) {
-          this.walletAddress = account.account;
+        const nextWalletAddress = account?.account ?? '';
+        if (this.walletAddress !== nextWalletAddress) {
+          this.walletAddress = nextWalletAddress;
+          this.resetSwapQuoteState();
         }
       });
 
@@ -321,10 +323,7 @@ export class HomeComponent {
     const previousFrom = this.fromToken;
     this.fromToken = this.toToken;
     this.toToken = previousFrom;
-    this.swapFlowFacade.reset();
-    this.quoteResult = undefined;
-    this.quoteError = '';
-    this.intentHash = '';
+    this.resetSwapQuoteState();
     this.loadMarketComparison();
   }
 
@@ -557,11 +556,23 @@ export class HomeComponent {
 
   private applySanitizedAmount(value: string, input?: HTMLInputElement): void {
     const sanitized = this.sanitizeAmountInput(value);
+    const previousAmount = this.amount;
     this.amount = sanitized;
 
     if (input && input.value !== sanitized) {
       input.value = sanitized;
     }
+
+    if (sanitized !== previousAmount) {
+      this.resetSwapQuoteState();
+    }
+  }
+
+  private resetSwapQuoteState(): void {
+    this.swapFlowFacade.reset();
+    this.quoteResult = undefined;
+    this.quoteError = '';
+    this.intentHash = '';
   }
 
   private sanitizeAmountInput(value: string): string {
@@ -608,10 +619,7 @@ export class HomeComponent {
       this.toToken = token;
     }
 
-    this.swapFlowFacade.reset();
-    this.quoteResult = undefined;
-    this.quoteError = '';
-    this.intentHash = '';
+    this.resetSwapQuoteState();
     this.closeTokenSelector();
     this.loadMarketComparison();
   }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,28 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HttpClient } from '@angular/common/http';
 import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import { ExchangeToken } from '@shared/models/exchange-token.model';
+import { SwapFlowFacade } from '@domains/exchange/application/swap-flow.facade';
+import type { SwapFlowState } from '@domains/exchange/models/swap.models';
 import { environment } from '../../../environments/environment';
 
 type TokenSelectorSide = 'from' | 'to';
-
-interface OneClickQuoteRequest {
-  dry: boolean;
-  slippageTolerance: number;
-  originAsset: string;
-  destinationAsset: string;
-  amount: string;
-  deadline: string;
-  userAddress: string;
-  authMethod: 'evm';
-  swapType: 'EXACT_INPUT';
-  isConfidential: boolean;
-  isAuthenticated: boolean;
-}
-
-interface QuoteApiResponse {
-  data: unknown;
-}
 
 type ComparisonTimeframe = '1H' | '1D' | '1W';
 
@@ -78,6 +63,7 @@ interface ComparisonGridLine {
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {
+  private readonly destroyRef = inject(DestroyRef);
   private readonly comparisonWidth = 720;
   private readonly comparisonHeight = 220;
   private readonly comparisonPadding = {
@@ -108,9 +94,10 @@ export class HomeComponent {
   public toToken = this.exchangeTokens[1];
   public isTokenSelectorOpen = false;
   public tokenSelectorSide: TokenSelectorSide | null = null;
-  public isQuoteLoading = false;
+  public swapFlowState: SwapFlowState = 'idle';
   public quoteError = '';
-  public quoteResult: unknown;
+  public quoteResult: Record<string, unknown> | undefined;
+  public intentHash = '';
   public comparison?: MarketComparisonResponse;
   public comparisonLines: ComparisonChartLine[] = [];
   public comparisonYLabels: ComparisonYLabel[] = [];
@@ -135,20 +122,45 @@ export class HomeComponent {
 
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly walletsService: WalletsService
+    private readonly walletsService: WalletsService,
+    private readonly swapFlowFacade: SwapFlowFacade
   ) {
-    this.walletsService.account.subscribe(account => {
-      if (account?.account) {
-        this.walletAddress = account.account;
-      }
-    });
+    this.walletsService.account
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(account => {
+        if (account?.account) {
+          this.walletAddress = account.account;
+        }
+      });
+
+    this.swapFlowFacade.state$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(state => {
+        this.swapFlowState = state;
+      });
+
+    this.swapFlowFacade.quotePreview$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(preview => {
+        this.quoteResult = preview?.raw;
+      });
+
+    this.swapFlowFacade.error$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(error => {
+        this.quoteError = error?.message ?? '';
+      });
+
+    this.swapFlowFacade.intentHash$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(intentHash => {
+        this.intentHash = intentHash ?? '';
+      });
+
     this.loadMarketComparison();
   }
 
   public submitQuote(): void {
-    this.quoteError = '';
-    this.quoteResult = undefined;
-
     if (!this.walletAddress) {
       this.quoteError = 'Connect wallet first.';
       return;
@@ -161,33 +173,45 @@ export class HomeComponent {
       return;
     }
 
-    this.isQuoteLoading = true;
+    if (this.quoteResult && this.canExecuteSwap()) {
+      void this.executeSwap(amount);
+      return;
+    }
 
-    this.httpClient
-      .post<QuoteApiResponse>(`${environment.apiUrl}/api/v1/quotes/one-click`, {
-        dry: true,
-        slippageTolerance: 50,
-        originAsset: this.fromToken.assetId,
-        destinationAsset: this.toToken.assetId,
-        amount,
-        deadline: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-        userAddress: this.walletAddress.toLowerCase(),
-        authMethod: 'evm',
-        swapType: 'EXACT_INPUT',
-        isConfidential: false,
-        isAuthenticated: true,
-      } satisfies OneClickQuoteRequest)
-      .subscribe({
-        next: response => {
-          this.quoteResult = response.data;
-          this.isQuoteLoading = false;
-        },
-        error: error => {
-          this.quoteError =
-            error?.error?.message || 'Quote request failed. Try again.';
-          this.isQuoteLoading = false;
-        },
-      });
+    void this.swapFlowFacade.requestQuotePreview(this.buildSwapInput(amount));
+  }
+
+  public isQuoteLoading(): boolean {
+    return (
+      this.swapFlowState === 'requestingQuote' ||
+      this.swapFlowState === 'validating' ||
+      this.swapFlowState === 'awaitingUserSignature' ||
+      this.swapFlowState === 'submittingTransaction'
+    );
+  }
+
+  private canExecuteSwap(): boolean {
+    return (
+      this.swapFlowState === 'idle' ||
+      this.swapFlowState === 'completed' ||
+      this.swapFlowState === 'failed'
+    );
+  }
+
+  private async executeSwap(amount: string): Promise<void> {
+    await this.swapFlowFacade.executeSwap(this.buildSwapInput(amount));
+  }
+
+  private buildSwapInput(amount: string) {
+    return {
+      originAsset: this.fromToken.assetId,
+      destinationAsset: this.toToken.assetId,
+      amount,
+      userAddress: this.walletAddress.toLowerCase(),
+      slippageTolerance: 50,
+      deadline: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      authMethod: 'evm' as const,
+    };
   }
 
   public changeComparisonTimeframe(timeframe: ComparisonTimeframe): void {
@@ -207,8 +231,10 @@ export class HomeComponent {
     const previousFrom = this.fromToken;
     this.fromToken = this.toToken;
     this.toToken = previousFrom;
+    this.swapFlowFacade.reset();
     this.quoteResult = undefined;
     this.quoteError = '';
+    this.intentHash = '';
     this.loadMarketComparison();
   }
 
@@ -238,7 +264,7 @@ export class HomeComponent {
   }
 
   public toAmountDisplay(): string {
-    const quote = this.quoteResult as Record<string, unknown> | undefined;
+    const quote = this.quoteResult;
     const amount =
       quote?.['amountOut'] ??
       quote?.['destinationAmount'] ??
@@ -248,11 +274,19 @@ export class HomeComponent {
       return String(amount);
     }
 
-    return '';
+    return this.swapFlowFacade.quotePreview?.amountOut ?? '';
   }
 
   public primaryActionLabel(): string {
-    return this.walletAddress ? 'Get quote' : 'Connect wallet';
+    if (!this.walletAddress) {
+      return 'Connect wallet';
+    }
+
+    if (this.quoteResult) {
+      return this.isQuoteLoading() ? 'Signing swap...' : 'Sign & swap';
+    }
+
+    return this.isQuoteLoading() ? 'Quoting...' : 'Get quote';
   }
 
   public onAmountKeydown(event: KeyboardEvent): void {
@@ -386,8 +420,10 @@ export class HomeComponent {
       this.toToken = token;
     }
 
+    this.swapFlowFacade.reset();
     this.quoteResult = undefined;
     this.quoteError = '';
+    this.intentHash = '';
     this.closeTokenSelector();
     this.loadMarketComparison();
   }

--- a/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
+++ b/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
@@ -1,0 +1,272 @@
+import { Injectable } from '@angular/core';
+import {
+  BehaviorSubject,
+  Observable,
+  filter,
+  firstValueFrom,
+  timeout,
+} from 'rxjs';
+import type { ApprovedIntentPrepareRequest } from '@mfe-contracts/intent-prepare.contract';
+import type { WalletGatewayEvent } from '@mfe-contracts/gateway-events';
+import type {
+  DefuseWalletSignatureResult,
+  WalletExecutionFailure,
+} from '@mfe-contracts/wallet-execution.types';
+import type {
+  WalletConnectionSnapshot,
+  WalletsMfeMountApi,
+} from '@mfe-contracts/wallet-mfe.types';
+import { AppLoggerService } from '@core/logging/app-logger.service';
+
+const SIGNATURE_WAIT_MS = 120_000;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WalletGatewayBridgeService {
+  private mountApi?: WalletsMfeMountApi;
+  private readonly snapshotSubject = new BehaviorSubject<
+    WalletConnectionSnapshot | undefined
+  >(undefined);
+  private pendingSignature?: {
+    resolve: (signature: DefuseWalletSignatureResult) => void;
+    reject: (error: WalletExecutionFailure) => void;
+  };
+
+  readonly snapshot$: Observable<WalletConnectionSnapshot | undefined> =
+    this.snapshotSubject.asObservable();
+
+  constructor(private readonly logger: AppLoggerService) {}
+
+  registerMountApi(api: WalletsMfeMountApi): void {
+    this.mountApi = api;
+    this.snapshotSubject.next(api.getSnapshot());
+  }
+
+  clearMountApi(): void {
+    this.mountApi = undefined;
+    this.rejectPendingSignature({
+      code: 'GATEWAY_UNAVAILABLE',
+      message: 'Wallet gateway unmounted',
+      retryable: true,
+    });
+  }
+
+  updateSnapshot(snapshot: WalletConnectionSnapshot): void {
+    this.snapshotSubject.next(snapshot);
+  }
+
+  handleExecutionStateChanged(payload: {
+    state: string;
+    reason?: string;
+    errorCode?: string;
+  }): void {
+    if (payload.state.endsWith('signRejected')) {
+      this.rejectPendingSignature({
+        code: 'SIGN_REJECTED',
+        message: payload.reason ?? 'Wallet action was cancelled',
+        retryable: true,
+      });
+      return;
+    }
+
+    if (payload.state.endsWith('signFailed')) {
+      this.rejectPendingSignature({
+        code: 'SIGN_FAILED',
+        message: payload.reason ?? 'Intent signature failed',
+        retryable: true,
+      });
+    }
+  }
+
+  handleIntentSigned(payload: { signature: Record<string, unknown> }): void {
+    if (!this.pendingSignature) {
+      return;
+    }
+
+    this.pendingSignature.resolve(payload.signature);
+    this.pendingSignature = undefined;
+  }
+
+  async runIntentSignFlow(input: {
+    traceId: string;
+    prepareRequest: ApprovedIntentPrepareRequest;
+  }): Promise<DefuseWalletSignatureResult> {
+    const snapshot = this.requireSnapshot();
+
+    if (!snapshot.account) {
+      throw this.executionFailure(
+        'NOT_CONNECTED',
+        'Connect wallet first',
+        false
+      );
+    }
+
+    if (!snapshot.isVerified) {
+      this.sendGatewayEvent({ type: 'VERIFY_REQUESTED' });
+      throw this.executionFailure(
+        'NOT_VERIFIED',
+        'Complete wallet verification before signing',
+        true
+      );
+    }
+
+    if (!this.canSendGatewayEvent()) {
+      throw this.executionFailure(
+        'GATEWAY_UNAVAILABLE',
+        'Wallet gateway is not ready for intent signing',
+        true
+      );
+    }
+
+    this.logger.log('info', 'Wallet gateway: prepare intent message', {
+      flowName: 'swap',
+      step: 'prepare_intent_message',
+      traceId: input.traceId,
+    });
+
+    this.sendGatewayEvent({
+      type: 'PREPARE_INTENT_MESSAGE_REQUESTED',
+      request: input.prepareRequest,
+    });
+
+    await this.waitForExecutionState(
+      'operating.awaitingIntentSign',
+      input.traceId
+    );
+
+    this.logger.log('info', 'Wallet gateway: sign requested', {
+      flowName: 'swap',
+      step: 'sign_requested',
+      traceId: input.traceId,
+    });
+
+    this.sendGatewayEvent({ type: 'SIGN_REQUESTED' });
+
+    return this.waitForIntentSignature(input.traceId);
+  }
+
+  abortExecution(): void {
+    this.sendGatewayEvent({ type: 'ABORT' });
+    this.rejectPendingSignature({
+      code: 'SIGN_FAILED',
+      message: 'Swap signing aborted',
+      retryable: true,
+    });
+  }
+
+  private canSendGatewayEvent(): boolean {
+    return typeof this.mountApi?.sendGatewayEvent === 'function';
+  }
+
+  private sendGatewayEvent(event: WalletGatewayEvent): void {
+    const send = this.mountApi?.sendGatewayEvent;
+    if (!send) {
+      throw this.executionFailure(
+        'GATEWAY_UNAVAILABLE',
+        'Wallet MFE does not expose sendGatewayEvent yet',
+        true
+      );
+    }
+
+    send(event);
+  }
+
+  private requireSnapshot(): WalletConnectionSnapshot {
+    const snapshot = this.snapshotSubject.value ?? this.mountApi?.getSnapshot();
+    if (!snapshot) {
+      throw this.executionFailure(
+        'GATEWAY_UNAVAILABLE',
+        'Wallet connection snapshot is unavailable',
+        true
+      );
+    }
+
+    return snapshot;
+  }
+
+  private waitForExecutionState(state: string, traceId: string): Promise<void> {
+    return firstValueFrom(
+      this.snapshot$.pipe(
+        filter(
+          (snapshot): snapshot is WalletConnectionSnapshot =>
+            snapshot?.executionState === state
+        ),
+        timeout({
+          each: SIGNATURE_WAIT_MS,
+          with: () => {
+            throw this.executionFailure(
+              'PREPARE_FAILED',
+              `Timed out waiting for wallet state ${state}`,
+              true
+            );
+          },
+        })
+      )
+    ).then(() => {
+      this.logger.log('info', 'Wallet gateway: execution state reached', {
+        flowName: 'swap',
+        step: state,
+        traceId,
+      });
+    });
+  }
+
+  private waitForIntentSignature(
+    traceId: string
+  ): Promise<DefuseWalletSignatureResult> {
+    if (this.pendingSignature) {
+      throw this.executionFailure(
+        'SIGN_FAILED',
+        'Another wallet signature is already in progress',
+        false
+      );
+    }
+
+    return new Promise<DefuseWalletSignatureResult>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.pendingSignature = undefined;
+        reject(
+          this.executionFailure(
+            'SIGN_FAILED',
+            'Timed out waiting for wallet signature',
+            true
+          )
+        );
+      }, SIGNATURE_WAIT_MS);
+
+      this.pendingSignature = {
+        resolve: signature => {
+          window.clearTimeout(timer);
+          this.logger.log('info', 'Wallet gateway: intent signed', {
+            flowName: 'swap',
+            step: 'intent_signed',
+            traceId,
+          });
+          resolve(signature);
+        },
+        reject: error => {
+          window.clearTimeout(timer);
+          reject(error);
+        },
+      };
+    });
+  }
+
+  private rejectPendingSignature(error: WalletExecutionFailure): void {
+    if (!this.pendingSignature) {
+      return;
+    }
+
+    this.pendingSignature.reject(error);
+    this.pendingSignature = undefined;
+  }
+
+  private executionFailure(
+    code: WalletExecutionFailure['code'],
+    message: string,
+    retryable: boolean
+  ): WalletExecutionFailure {
+    return { code, message, retryable };
+  }
+}

--- a/src/app/shared/mfe/wallets/wallets.component.ts
+++ b/src/app/shared/mfe/wallets/wallets.component.ts
@@ -15,6 +15,7 @@ import {
 } from '@mfe-contracts/wallet-mfe.types';
 import { WalletAccountChangedPayload } from '@mfe-contracts/payloads';
 import { AppLoggerService } from '@core/logging/app-logger.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
 import { environment } from '../../../../environments/environment';
 
 @Component({
@@ -33,6 +34,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
 
   constructor(
     private walletsService: WalletsService,
+    private walletGatewayBridge: WalletGatewayBridgeService,
     private logger: AppLoggerService,
     private ngZone: NgZone
   ) {}
@@ -91,6 +93,16 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
               this.walletsService.requestClose();
             });
           },
+          onExecutionStateChanged: payload => {
+            this.ngZone.run(() => {
+              this.walletGatewayBridge.handleExecutionStateChanged(payload);
+            });
+          },
+          onIntentSigned: payload => {
+            this.ngZone.run(() => {
+              this.walletGatewayBridge.handleIntentSigned(payload);
+            });
+          },
         },
       });
       this.unsubscribeEvents?.();
@@ -99,11 +111,13 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
       if (this.isMountApi(mountResult)) {
         this.unmountMfe = mountResult.unmount;
         this.ngZone.run(() => {
+          this.walletGatewayBridge.registerMountApi(mountResult);
           this.applyConnectionSnapshot(mountResult.getSnapshot());
         });
         this.unsubscribeEvents = mountResult.subscribe(event => {
           if (event.type === 'connection.snapshot.updated') {
             this.ngZone.run(() => {
+              this.walletGatewayBridge.updateSnapshot(event.payload);
               this.applyConnectionSnapshot(event.payload);
             });
           }
@@ -157,6 +171,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
     this.isDestroyed = true;
     this.unsubscribeEvents?.();
     this.unsubscribeEvents = undefined;
+    this.walletGatewayBridge.clearMountApi();
     this.unmountMfe?.();
     this.unmountMfe = undefined;
   }


### PR DESCRIPTION
Introduce exchange domain workflow, MFE gateway contracts, and wallet bridge so the host can fetch BFF-approved prepare packages, drive MFE prepare/sign events, and relay signed intents without quoteHashes in MFE.