### PR TITLE
release: promote develop to master with Privy bridge and swap fixes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -8,6 +8,11 @@ import { SidebarComponent } from '@components/sidebar/sidebar.component';
 import { SharedModule } from '@shared/shared.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { PrivyBridgeService } from '@core/privy/privy-bridge.service';
+
+function initializePrivyBridge(privyBridgeService: PrivyBridgeService) {
+  return () => privyBridgeService.initialize();
+}
 
 @NgModule({
   declarations: [
@@ -22,7 +27,15 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
     AppRoutingModule,
     SharedModule,
   ],
-  providers: [provideAnimationsAsync()],
+  providers: [
+    provideAnimationsAsync(),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializePrivyBridge,
+      deps: [PrivyBridgeService],
+      multi: true,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/core/privy/privy-bridge.service.ts
+++ b/src/app/core/privy/privy-bridge.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { resolvePrivyHostBridge } from './privy-host-bridge';
+import type { CraftscriptPrivyBridge } from './privy-bridge.types';
+import './privy-bridge.types';
+
+@Injectable({ providedIn: 'root' })
+export class PrivyBridgeService implements OnDestroy {
+  private assignedBridge: CraftscriptPrivyBridge | undefined;
+
+  initialize(): void {
+    const bridge = resolvePrivyHostBridge();
+    if (!bridge || window.craftscriptPrivy === bridge) {
+      return;
+    }
+
+    window.craftscriptPrivy = bridge;
+    this.assignedBridge = bridge;
+  }
+
+  ngOnDestroy(): void {
+    if (
+      this.assignedBridge &&
+      window.craftscriptPrivy === this.assignedBridge
+    ) {
+      delete window.craftscriptPrivy;
+    }
+
+    this.assignedBridge = undefined;
+  }
+}

--- a/src/app/core/privy/privy-bridge.types.ts
+++ b/src/app/core/privy/privy-bridge.types.ts
@@ -1,0 +1,41 @@
+export type PrivyEmbeddedWallet = {
+  id?: string;
+  address?: string;
+  walletClientType?: string;
+  chainType?: string;
+  getEthereumProvider?: () => Promise<{
+    request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+  }>;
+};
+
+export type PrivyBridgeUser = {
+  id?: string;
+  email?: { address?: string };
+  linkedAccounts?: Array<Record<string, unknown>>;
+  wallet?: PrivyEmbeddedWallet;
+};
+
+export type CraftscriptPrivyBridge = {
+  login: () => Promise<PrivyBridgeUser | void>;
+  getAccessToken: () => Promise<string | null>;
+  getUser: () => Promise<PrivyBridgeUser | null>;
+  getEmbeddedWallet: () => Promise<PrivyEmbeddedWallet | null>;
+  signMessage: (input: {
+    message: string;
+    address?: string;
+  }) => Promise<{ signature: string }>;
+  sendTransaction: (input: {
+    from: string;
+    to: string;
+    value?: string;
+    data?: string;
+  }) => Promise<{ hash: string }>;
+};
+
+declare global {
+  interface Window {
+    craftscriptPrivy?: CraftscriptPrivyBridge;
+    craftscriptPrivySource?: CraftscriptPrivyBridge;
+  }
+}
+

--- a/src/app/core/privy/privy-host-bridge.ts
+++ b/src/app/core/privy/privy-host-bridge.ts
@@ -1,0 +1,34 @@
+import type { CraftscriptPrivyBridge } from './privy-bridge.types';
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isCraftscriptPrivyBridge(
+  value: unknown
+): value is CraftscriptPrivyBridge {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  return (
+    typeof value['login'] === 'function' &&
+    typeof value['getAccessToken'] === 'function' &&
+    typeof value['getUser'] === 'function' &&
+    typeof value['getEmbeddedWallet'] === 'function' &&
+    typeof value['signMessage'] === 'function' &&
+    typeof value['sendTransaction'] === 'function'
+  );
+}
+
+export function resolvePrivyHostBridge(): CraftscriptPrivyBridge | undefined {
+  if (isCraftscriptPrivyBridge(window.craftscriptPrivy)) {
+    return window.craftscriptPrivy;
+  }
+
+  if (isCraftscriptPrivyBridge(window.craftscriptPrivySource)) {
+    return window.craftscriptPrivySource;
+  }
+
+  return undefined;
+}

--- a/src/app/domains/exchange/application/swap-execution.workflow.ts
+++ b/src/app/domains/exchange/application/swap-execution.workflow.ts
@@ -10,10 +10,10 @@ import type {
   SwapQuotePreview,
   SwapQuoteRequest,
 } from '@domains/exchange/models/swap.models';
+import { toSwapFlowError } from '@domains/exchange/models/swap-flow-error';
 import { SwapApiClient } from '@domains/exchange/data-access/swap-api.client';
 import { IntentRelayService } from '@domains/exchange/data-access/intent-relay.service';
 import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
-import type { WalletExecutionFailure } from '@mfe-contracts/wallet-execution.types';
 
 @Injectable({
   providedIn: 'root',
@@ -109,77 +109,7 @@ export class SwapExecutionWorkflow {
   }
 
   private toFlowError(step: SwapFlowState, error: unknown): SwapFlowError {
-    if (this.isFlowError(error)) {
-      return error;
-    }
-
-    if (this.isWalletExecutionFailure(error)) {
-      return {
-        code: error.code,
-        message: error.message,
-        retryable: error.retryable,
-        step,
-      };
-    }
-
-    if (this.isApiError(error)) {
-      return {
-        code: error.code,
-        message: error.message,
-        retryable: error.retryable,
-        step,
-        details: error.details,
-      };
-    }
-
-    const message =
-      error instanceof Error
-        ? error.message
-        : 'Swap execution failed unexpectedly';
-
-    return {
-      code: 'SWAP_FAILED',
-      message,
-      retryable: true,
-      step,
-    };
-  }
-
-  private isFlowError(error: unknown): error is SwapFlowError {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'step' in error &&
-      'code' in error &&
-      'message' in error
-    );
-  }
-
-  private isWalletExecutionFailure(
-    error: unknown
-  ): error is WalletExecutionFailure {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      'message' in error &&
-      'retryable' in error
-    );
-  }
-
-  private isApiError(error: unknown): error is {
-    code: string;
-    message: string;
-    retryable: boolean;
-    details?: unknown;
-  } {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      'message' in error &&
-      'retryable' in error
-    );
+    return toSwapFlowError(step, error, 'Swap execution failed unexpectedly');
   }
 
   private logTransition(

--- a/src/app/domains/exchange/application/swap-flow.facade.spec.ts
+++ b/src/app/domains/exchange/application/swap-flow.facade.spec.ts
@@ -1,14 +1,19 @@
-import {
-  discardPeriodicTasks,
-  fakeAsync,
-  tick,
-} from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { Subject } from 'rxjs';
-import type { SwapQuotePreview } from '@domains/exchange/models/swap.models';
+import type {
+  ApprovedSwapPreparePackage,
+  SwapQuotePreview,
+} from '@domains/exchange/models/swap.models';
 import { SwapExecutionWorkflow } from './swap-execution.workflow';
 import { SwapFlowFacade, SwapFormInput } from './swap-flow.facade';
 
-class SwapExecutionWorkflowStub {
+class SwapExecutionWorkflowStub
+  implements
+    Pick<
+      SwapExecutionWorkflow,
+      'requestQuotePreview' | 'requestQuotePreviewStream' | 'executeSwap'
+    >
+{
   public readonly quoteCalls: Array<{
     input: SwapFormInput;
     traceId: string;
@@ -24,9 +29,58 @@ class SwapExecutionWorkflowStub {
     return response.asObservable();
   }
 
-  public executeSwap = jasmine
-    .createSpy('executeSwap')
-    .and.resolveTo({ traceId: 'trace', preparePackage: {}, intentHash: 'hash' });
+  public async requestQuotePreview(
+    input: SwapFormInput,
+    traceId: string
+  ): Promise<{ traceId: string; preview: SwapQuotePreview }> {
+    return {
+      traceId,
+      preview: preview(input.amount),
+    };
+  }
+
+  public async executeSwap(
+    _input: SwapFormInput,
+    traceId: string
+  ): Promise<{
+    traceId: string;
+    preparePackage: ApprovedSwapPreparePackage;
+    intentHash: string;
+  }> {
+    return {
+      traceId,
+      preparePackage: approvedPreparePackage(),
+      intentHash: 'hash',
+    };
+  }
+}
+
+function preview(amountOut: string): SwapQuotePreview {
+  return {
+    amountOut,
+    raw: { amountOut },
+  };
+}
+
+function approvedPreparePackage(): ApprovedSwapPreparePackage {
+  return {
+    protocol: 'near-intents',
+    kind: 'swap',
+    quoteHashes: ['quote-hash'],
+    signerId: '0x0000000000000000000000000000000000000001',
+    authMethod: 'evm',
+    deadlineTimestamp: 1_765_497_600,
+    tokenDeltas: [
+      {
+        assetId: 'nep141:usdc',
+        amount: '-1000000',
+      },
+      {
+        assetId: 'nep141:near',
+        amount: '1000000',
+      },
+    ],
+  };
 }
 
 describe('SwapFlowFacade quote preview refresh', () => {
@@ -35,7 +89,7 @@ describe('SwapFlowFacade quote preview refresh', () => {
 
   beforeEach(() => {
     workflow = new SwapExecutionWorkflowStub();
-    facade = new SwapFlowFacade(workflow as unknown as SwapExecutionWorkflow);
+    facade = new SwapFlowFacade(workflow);
   });
 
   afterEach(fakeAsync(() => {
@@ -118,10 +172,4 @@ describe('SwapFlowFacade quote preview refresh', () => {
     };
   }
 
-  function preview(amountOut: string): SwapQuotePreview {
-    return {
-      amountOut,
-      raw: { amountOut },
-    };
-  }
 });

--- a/src/app/domains/exchange/application/swap-flow.facade.ts
+++ b/src/app/domains/exchange/application/swap-flow.facade.ts
@@ -15,6 +15,7 @@ import type {
   SwapFlowState,
   SwapQuotePreview,
 } from '@domains/exchange/models/swap.models';
+import { toSwapFlowError } from '@domains/exchange/models/swap-flow-error';
 import { SwapExecutionWorkflow } from './swap-execution.workflow';
 
 export type SwapFormInput = {
@@ -217,31 +218,6 @@ export class SwapFlowFacade {
   }
 
   private toFlowError(step: SwapFlowState, error: unknown): SwapFlowError {
-    if (isSwapFlowError(error)) {
-      return { ...error, step };
-    }
-
-    return {
-      code: 'SWAP_FAILED',
-      message:
-        error instanceof Error
-          ? error.message
-          : 'Swap flow failed unexpectedly',
-      retryable: true,
-      step,
-    };
+    return toSwapFlowError(step, error, 'Swap flow failed unexpectedly');
   }
-}
-
-function isSwapFlowError(error: unknown): error is SwapFlowError {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof error.code === 'string' &&
-    'message' in error &&
-    typeof error.message === 'string' &&
-    'retryable' in error &&
-    typeof error.retryable === 'boolean'
-  );
 }

--- a/src/app/domains/exchange/application/swap-flow.facade.ts
+++ b/src/app/domains/exchange/application/swap-flow.facade.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import {
   BehaviorSubject,
   EMPTY,
@@ -27,6 +27,11 @@ export type SwapFormInput = {
   authMethod: 'evm' | 'near';
 };
 
+type SwapExecutionWorkflowPort = Pick<
+  SwapExecutionWorkflow,
+  'requestQuotePreview' | 'requestQuotePreviewStream' | 'executeSwap'
+>;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -52,7 +57,10 @@ export class SwapFlowFacade {
   readonly error$ = this.errorSubject.asObservable();
   readonly intentHash$ = this.intentHashSubject.asObservable();
 
-  constructor(private readonly workflow: SwapExecutionWorkflow) {
+  constructor(
+    @Inject(SwapExecutionWorkflow)
+    private readonly workflow: SwapExecutionWorkflowPort
+  ) {
     this.quoteInputSubject
       .pipe(
         distinctUntilChanged(
@@ -171,7 +179,9 @@ export class SwapFlowFacade {
           }),
           catchError(error => {
             if (requestVersion === this.quoteRequestVersion) {
-              this.errorSubject.next(this.toFlowError('requestingQuote', error));
+              this.errorSubject.next(
+                this.toFlowError('requestingQuote', error)
+              );
               this.setState('idle');
             }
 
@@ -207,14 +217,8 @@ export class SwapFlowFacade {
   }
 
   private toFlowError(step: SwapFlowState, error: unknown): SwapFlowError {
-    if (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      'message' in error &&
-      'retryable' in error
-    ) {
-      return { ...(error as SwapFlowError), step };
+    if (isSwapFlowError(error)) {
+      return { ...error, step };
     }
 
     return {
@@ -227,4 +231,17 @@ export class SwapFlowFacade {
       step,
     };
   }
+}
+
+function isSwapFlowError(error: unknown): error is SwapFlowError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    'message' in error &&
+    typeof error.message === 'string' &&
+    'retryable' in error &&
+    typeof error.retryable === 'boolean'
+  );
 }

--- a/src/app/domains/exchange/models/swap-flow-error.spec.ts
+++ b/src/app/domains/exchange/models/swap-flow-error.spec.ts
@@ -1,0 +1,87 @@
+import type { SwapFlowError } from './swap.models';
+import {
+  BaseSwapError,
+  SwapFlowException,
+  parseApiErrorEnvelope,
+  parseSwapFlowError,
+  toSwapFlowError,
+} from './swap-flow-error';
+
+describe('swap flow error utilities', () => {
+  it('preserves SwapFlowException fields', () => {
+    const error = new SwapFlowException('awaitingUserSignature', {
+      code: 'WALLET_REJECTED',
+      message: 'User rejected signature',
+      retryable: true,
+      details: { source: 'wallet' },
+    });
+
+    expect(toSwapFlowError('validating', error, 'fallback')).toEqual({
+      code: 'WALLET_REJECTED',
+      message: 'User rejected signature',
+      retryable: true,
+      details: { source: 'wallet' },
+      step: 'awaitingUserSignature',
+    });
+  });
+
+  it('applies the current step to base swap errors', () => {
+    const error = new BaseSwapError({
+      code: 'QUOTE_FAILED',
+      message: 'Quote unavailable',
+      retryable: true,
+    });
+
+    expect(toSwapFlowError('requestingQuote', error, 'fallback')).toEqual({
+      code: 'QUOTE_FAILED',
+      message: 'Quote unavailable',
+      retryable: true,
+      step: 'requestingQuote',
+    });
+  });
+
+  it('parses serialized swap flow errors', () => {
+    const error: SwapFlowError = {
+      code: 'INTENT_FAILED',
+      message: 'Intent relay failed',
+      retryable: false,
+      step: 'submittingTransaction',
+    };
+
+    expect(parseSwapFlowError(error)).toEqual(error);
+    expect(toSwapFlowError('validating', error, 'fallback')).toEqual(error);
+  });
+
+  it('parses api error envelopes without trusting arbitrary objects', () => {
+    expect(
+      parseApiErrorEnvelope({
+        code: 'API_FAILED',
+        message: 'Backend rejected request',
+        retryable: false,
+        details: { status: 400 },
+      })
+    ).toEqual({
+      code: 'API_FAILED',
+      message: 'Backend rejected request',
+      retryable: false,
+      details: { status: 400 },
+    });
+
+    expect(
+      parseApiErrorEnvelope({
+        code: 'API_FAILED',
+        message: 'Backend rejected request',
+        retryable: 'false',
+      })
+    ).toBeUndefined();
+  });
+
+  it('normalizes unknown errors with the fallback message', () => {
+    expect(toSwapFlowError('validating', null, 'Swap failed')).toEqual({
+      code: 'SWAP_FAILED',
+      message: 'Swap failed',
+      retryable: true,
+      step: 'validating',
+    });
+  });
+});

--- a/src/app/domains/exchange/models/swap-flow-error.ts
+++ b/src/app/domains/exchange/models/swap-flow-error.ts
@@ -1,0 +1,162 @@
+import type { ApiErrorEnvelope } from '@mfe-contracts/api-envelope';
+import type { SwapFlowError, SwapFlowState } from './swap.models';
+
+type BaseSwapErrorInput = {
+  code: string;
+  message: string;
+  retryable: boolean;
+  details?: unknown;
+};
+
+const swapFlowStates = [
+  'idle',
+  'validating',
+  'requestingQuote',
+  'awaitingUserSignature',
+  'submittingTransaction',
+  'confirming',
+  'completed',
+  'failed',
+] satisfies readonly SwapFlowState[];
+
+export class BaseSwapError extends Error {
+  readonly code: string;
+  readonly retryable: boolean;
+  readonly details?: unknown;
+
+  constructor({ code, message, retryable, details }: BaseSwapErrorInput) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+    this.retryable = retryable;
+    this.details = details;
+  }
+
+  toApiErrorEnvelope(): ApiErrorEnvelope {
+    const envelope: ApiErrorEnvelope = {
+      code: this.code,
+      message: this.message,
+      retryable: this.retryable,
+    };
+
+    if (this.details !== undefined) {
+      envelope.details = this.details;
+    }
+
+    return envelope;
+  }
+}
+
+export class SwapFlowException extends BaseSwapError {
+  readonly step: SwapFlowState;
+
+  constructor(step: SwapFlowState, input: BaseSwapErrorInput) {
+    super(input);
+    this.step = step;
+  }
+
+  toSwapFlowError(): SwapFlowError {
+    return {
+      ...this.toApiErrorEnvelope(),
+      step: this.step,
+    };
+  }
+}
+
+export function toSwapFlowError(
+  step: SwapFlowState,
+  error: unknown,
+  fallbackMessage: string
+): SwapFlowError {
+  if (error instanceof SwapFlowException) {
+    return error.toSwapFlowError();
+  }
+
+  if (error instanceof BaseSwapError) {
+    return {
+      ...error.toApiErrorEnvelope(),
+      step,
+    };
+  }
+
+  const flowError = parseSwapFlowError(error);
+  if (flowError) {
+    return flowError;
+  }
+
+  const apiError = parseApiErrorEnvelope(error);
+  if (apiError) {
+    return {
+      ...apiError,
+      step,
+    };
+  }
+
+  return {
+    code: 'SWAP_FAILED',
+    message: error instanceof Error ? error.message : fallbackMessage,
+    retryable: true,
+    step,
+  };
+}
+
+export function parseSwapFlowError(error: unknown): SwapFlowError | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  const step = error['step'];
+  if (!isSwapFlowState(step)) {
+    return undefined;
+  }
+
+  const apiError = parseApiErrorEnvelope(error);
+  if (!apiError) {
+    return undefined;
+  }
+
+  return {
+    ...apiError,
+    step,
+  };
+}
+
+export function parseApiErrorEnvelope(
+  error: unknown
+): ApiErrorEnvelope | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  const code = error['code'];
+  const message = error['message'];
+  const retryable = error['retryable'];
+
+  if (
+    typeof code !== 'string' ||
+    typeof message !== 'string' ||
+    typeof retryable !== 'boolean'
+  ) {
+    return undefined;
+  }
+
+  const envelope: ApiErrorEnvelope = {
+    code,
+    message,
+    retryable,
+  };
+
+  if (error['details'] !== undefined) {
+    envelope.details = error['details'];
+  }
+
+  return envelope;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isSwapFlowState(value: unknown): value is SwapFlowState {
+  return swapFlowStates.some(state => state === value);
+}

--- a/src/app/pages/home/home-price.utils.ts
+++ b/src/app/pages/home/home-price.utils.ts
@@ -72,9 +72,7 @@ export function formatSwapFiatEstimate(value: number | undefined): string {
   const sign = value < 0 ? '-' : '';
 
   if (absValue >= 1e15) {
-    return `${sign}$${value
-      .toExponential(2)
-      .replace('.', ',')}`;
+    return `${sign}$${value.toExponential(2).replace('.', ',')}`;
   }
 
   if (absValue >= 1e9) {

--- a/src/app/shared/utils/amount-format.utils.spec.ts
+++ b/src/app/shared/utils/amount-format.utils.spec.ts
@@ -12,48 +12,32 @@ import {
 
 describe('amount-format.utils', () => {
   const maxFractionDigits = 18;
+  const keyEvent = (
+    key: string,
+    init: Omit<KeyboardEventInit, 'key'> = {}
+  ): KeyboardEvent => new KeyboardEvent('keydown', { key, ...init });
 
   describe('resolveAmountKeydownAction', () => {
     it('allows navigation and digit keys', () => {
-      expect(
-        resolveAmountKeydownAction({ key: '1' } as KeyboardEvent)
-      ).toBe('allow');
-      expect(
-        resolveAmountKeydownAction({ key: 'ArrowLeft' } as KeyboardEvent)
-      ).toBe('allow');
-      expect(
-        resolveAmountKeydownAction({
-          key: 'a',
-          ctrlKey: true,
-        } as KeyboardEvent)
-      ).toBe('allow');
+      expect(resolveAmountKeydownAction(keyEvent('1'))).toBe('allow');
+      expect(resolveAmountKeydownAction(keyEvent('ArrowLeft'))).toBe('allow');
+      expect(resolveAmountKeydownAction(keyEvent('a', { ctrlKey: true }))).toBe(
+        'allow'
+      );
     });
 
     it('routes decimal separator keys to dedicated handling', () => {
       expect(
-        resolveAmountKeydownAction({
-          key: 'б',
-          code: 'Comma',
-        } as KeyboardEvent)
+        resolveAmountKeydownAction(keyEvent('б', { code: 'Comma' }))
       ).toBe('decimal-separator');
     });
 
     it('blocks scientific notation and other printable characters', () => {
-      expect(resolveAmountKeydownAction({ key: 'e' } as KeyboardEvent)).toBe(
-        'block'
-      );
-      expect(resolveAmountKeydownAction({ key: 'E' } as KeyboardEvent)).toBe(
-        'block'
-      );
-      expect(resolveAmountKeydownAction({ key: '+' } as KeyboardEvent)).toBe(
-        'block'
-      );
-      expect(resolveAmountKeydownAction({ key: '-' } as KeyboardEvent)).toBe(
-        'block'
-      );
-      expect(resolveAmountKeydownAction({ key: 'a' } as KeyboardEvent)).toBe(
-        'block'
-      );
+      expect(resolveAmountKeydownAction(keyEvent('e'))).toBe('block');
+      expect(resolveAmountKeydownAction(keyEvent('E'))).toBe('block');
+      expect(resolveAmountKeydownAction(keyEvent('+'))).toBe('block');
+      expect(resolveAmountKeydownAction(keyEvent('-'))).toBe('block');
+      expect(resolveAmountKeydownAction(keyEvent('a'))).toBe('block');
     });
   });
 
@@ -118,7 +102,9 @@ describe('amount-format.utils', () => {
     });
 
     it('treats dot-only thousands grouping as not having a decimal separator', () => {
-      expect(displayHasDecimalSeparator('1.000', maxFractionDigits)).toBe(false);
+      expect(displayHasDecimalSeparator('1.000', maxFractionDigits)).toBe(
+        false
+      );
       expect(displayHasDecimalSeparator('10.000.000', maxFractionDigits)).toBe(
         false
       );
@@ -139,7 +125,9 @@ describe('amount-format.utils', () => {
     });
 
     it('accepts dot decimal input', () => {
-      expect(normalizeAmountStorage('1250.5', maxFractionDigits)).toBe('1250.5');
+      expect(normalizeAmountStorage('1250.5', maxFractionDigits)).toBe(
+        '1250.5'
+      );
     });
 
     it('caps fractional digits at max precision', () => {
@@ -190,7 +178,9 @@ describe('amount-format.utils', () => {
   describe('typing flow', () => {
     it('supports entering 0,1 step by step', () => {
       let storage = normalizeAmountStorage('0', maxFractionDigits);
-      expect(formatSwapAmountDisplay(storage, maxFractionDigits, true)).toBe('0');
+      expect(formatSwapAmountDisplay(storage, maxFractionDigits, true)).toBe(
+        '0'
+      );
 
       storage = normalizeAmountStorage('0,', maxFractionDigits);
       expect(storage).toBe('0.');

--- a/src/app/shared/utils/amount-format.utils.ts
+++ b/src/app/shared/utils/amount-format.utils.ts
@@ -21,9 +21,7 @@ export type AmountKeydownAction = 'allow' | 'block' | 'decimal-separator';
 
 export function isAmountInputControlKey(event: KeyboardEvent): boolean {
   return (
-    AMOUNT_INPUT_CONTROL_KEYS.includes(
-      event.key as (typeof AMOUNT_INPUT_CONTROL_KEYS)[number]
-    ) ||
+    AMOUNT_INPUT_CONTROL_KEYS.some(controlKey => controlKey === event.key) ||
     event.ctrlKey ||
     event.metaKey
   );
@@ -44,9 +42,7 @@ export function isDecimalSeparatorInputKey(event: KeyboardEvent): boolean {
 }
 
 export function isBlockedScientificNotationKey(key: string): boolean {
-  return BLOCKED_AMOUNT_INPUT_KEYS.includes(
-    key as (typeof BLOCKED_AMOUNT_INPUT_KEYS)[number]
-  );
+  return BLOCKED_AMOUNT_INPUT_KEYS.some(blockedKey => blockedKey === key);
 }
 
 export function resolveAmountKeydownAction(
@@ -88,10 +84,7 @@ export function formatWholeWithDots(whole: string): string {
     return '0';
   }
 
-  return digits.replace(
-    /\B(?=(\d{3})+(?!\d))/g,
-    AMOUNT_THOUSAND_SEPARATOR
-  );
+  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, AMOUNT_THOUSAND_SEPARATOR);
 }
 
 export function parseDisplayedAmount(
@@ -125,13 +118,13 @@ export function parseDisplayedAmount(
       .replace(/\D/g, '');
     const head = cleaned.slice(0, lastDot);
     const tailIsDecimal =
-      tail.length > 0 &&
-      tail.length <= maxFractionDigits &&
-      tail.length < 3;
+      tail.length > 0 && tail.length <= maxFractionDigits && tail.length < 3;
 
     if (tailIsDecimal) {
       return {
-        whole: stripLeadingZeros(stripThousands(head, AMOUNT_THOUSAND_SEPARATOR)),
+        whole: stripLeadingZeros(
+          stripThousands(head, AMOUNT_THOUSAND_SEPARATOR)
+        ),
         fraction: tail,
       };
     }

--- a/src/styles/exchange-page.scss
+++ b/src/styles/exchange-page.scss
@@ -262,12 +262,16 @@
     height: 52px;
     box-sizing: border-box;
     align-items: center;
-    padding: 0 12px 0 12px;
+    padding: 0 12px;
     border: 1px solid rgb(183 199 213 / 24%);
     border-radius: 16px;
     margin: 0;
     appearance: none;
-    background: linear-gradient(180deg, rgb(10 19 25 / 72%), rgb(9 17 23 / 72%));
+    background: linear-gradient(
+      180deg,
+      rgb(10 19 25 / 72%),
+      rgb(9 17 23 / 72%)
+    );
     box-shadow:
       inset 0 0 0 1px rgb(255 255 255 / 4%),
       0 0 24px rgb(18 36 48 / 18%);
@@ -280,8 +284,8 @@
 
     &__value {
       display: inline-flex;
-      min-width: 0;
       width: auto;
+      min-width: 0;
       align-items: center;
       gap: 10px;
     }
@@ -298,11 +302,11 @@
       width: 22px;
       height: 22px;
       flex-shrink: 0;
-      place-items: center;
       margin-left: 2px;
       color: rgb(255 255 255 / 85%);
       font-size: 22px;
       line-height: 1;
+      place-items: center;
     }
   }
 
@@ -531,11 +535,6 @@
       cursor: pointer;
       font-size: 13px;
       text-transform: uppercase;
-
-      &:disabled {
-        cursor: default;
-        opacity: 0.45;
-      }
     }
 
     .active {
@@ -557,17 +556,22 @@
       background: #0e1416;
       color: #fff;
       font-size: 13px;
-
-      &:disabled {
-        cursor: default;
-        opacity: 0.55;
-      }
     }
 
     .active {
       border-color: var(--exchange-orange);
       color: var(--exchange-orange);
     }
+  }
+
+  .tabs button:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+
+  .range button:disabled {
+    cursor: default;
+    opacity: 0.55;
   }
 
   .marketBody {
@@ -583,8 +587,8 @@
   .marketAdvanced {
     overflow: hidden;
     min-height: 0;
-    margin-top: 18px;
     flex: 1 1 auto;
+    margin-top: 18px;
 
     app-live-chart {
       display: block;


### PR DESCRIPTION
## Summary
- Promote develop to master.
- Expose the typed window.craftscriptPrivy host bridge for wallet MFE integration without bundling the Privy React SDK in the Angular shell.
- Keep Privy runtime config out of committed environment files.
- Centralize swap flow error handling with reusable domain error utilities and serialized API/MFE error parsing.
- Fix swap flow test typing around workflow stubs.
- Refine exchange quote amount/rate formatting and related specs.
- Adjust exchange page styles for the updated quote display.

## Included PRs
- #99 fix: expose Privy host bridge without SDK bundle
- #98 feat(auth): expose Privy host bridge
- #100 refactor: centralize swap flow error handling

## Notes
- This is a release promotion PR from develop to master.
- Privy SDK bundling was intentionally avoided to keep Angular production builds clear of incompatible transitive dependencies.
