### PR TITLE
release: Angular Privy onboarding, wallets, and balances

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,11 @@ const routes: Routes = [
       import('./pages/home/home.module').then(m => m.HomeModule),
   },
   {
+    path: '',
+    loadChildren: () =>
+      import('./pages/auth/auth.module').then(m => m.AuthModule),
+  },
+  {
     path: 'farm',
     loadChildren: () =>
       import('./pages/farm/farm.module').then(m => m.FarmModule),

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -8,6 +8,12 @@
         src="../../../assets/img/logo/logo.svg" />
     </a>
     <div class="header__content_connect">
+      <a
+        class="header__account-link"
+        [routerLink]="session ? '/profile' : '/login'"
+        routerLinkActive="_active">
+        {{ session ? 'Profile' : 'Sign in' }}
+      </a>
       <app-wallet-bar />
     </div>
   </div>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -33,9 +33,29 @@
       display: flex;
       align-items: center;
       justify-content: flex-end;
+      gap: 0.75rem;
       padding-top: 6px;
       padding-right: 1rem;
       grid-column: 6 / 8;
+    }
+
+    &__account-link {
+      display: inline-flex;
+      min-height: 2.25rem;
+      align-items: center;
+      padding: 0 0.85rem;
+      border: 1px solid rgb(255 255 255 / 18%);
+      border-radius: 8px;
+      color: var(--main-text-color);
+      font-size: 0.85rem;
+      line-height: 1;
+      text-decoration: none;
+      white-space: nowrap;
+
+      &._active {
+        border-color: var(--primary-text-color);
+        color: var(--primary-text-color);
+      }
     }
 
     &__line,
@@ -61,6 +81,11 @@
       justify-content: center;
       padding-top: 6px;
       grid-column: 3 / 5;
+    }
+
+    &__account-link {
+      padding: 0 0.65rem;
+      font-size: 0.78rem;
     }
   }
 }

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,7 +1,10 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 import { HeaderComponent } from './header.component';
+import { AuthSessionService } from '@core/auth/auth-session.service';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -9,7 +12,16 @@ describe('HeaderComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
       declarations: [HeaderComponent],
+      providers: [
+        {
+          provide: AuthSessionService,
+          useValue: {
+            session$: of(null),
+          },
+        },
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     });
     fixture = TestBed.createComponent(HeaderComponent);

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -2,6 +2,8 @@ import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
 import { filter, Subscription } from 'rxjs';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import type { AuthSession } from '@core/auth/auth-session.types';
 
 @Component({
   selector: 'app-header',
@@ -15,10 +17,15 @@ export class HeaderComponent implements OnInit, OnDestroy {
   public originUrl: string = environment.origin;
   public horizontalLineAnimating = true;
   public lineResetKey = 0;
+  public session: AuthSession | null = null;
 
   private routerSubscription?: Subscription;
+  private sessionSubscription?: Subscription;
 
-  constructor(private readonly router: Router) {}
+  constructor(
+    private readonly router: Router,
+    public readonly authSession: AuthSessionService
+  ) {}
 
   public ngOnInit(): void {
     this.isMobileView = this.currentWidth <= 768;
@@ -29,10 +36,15 @@ export class HeaderComponent implements OnInit, OnDestroy {
         this.horizontalLineAnimating = true;
         this.lineResetKey += 1;
       });
+
+    this.sessionSubscription = this.authSession.session$.subscribe(session => {
+      this.session = session;
+    });
   }
 
   public ngOnDestroy(): void {
     this.routerSubscription?.unsubscribe();
+    this.sessionSubscription?.unsubscribe();
   }
 
   @HostListener('window:resize', ['$event'])

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -21,6 +21,11 @@ export class SidebarComponent {
       url: '/',
       isActive: true,
     },
+    {
+      name: 'Profile',
+      url: '/profile',
+      isActive: true,
+    },
   ];
 
   public sidebarFinansialLinks = [

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -1,0 +1,145 @@
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AuthSessionService } from './auth-session.service';
+import { environment } from '../../../environments/environment';
+import type { CraftscriptPrivyBridge } from '@core/privy/privy-bridge.types';
+
+function bridge(): CraftscriptPrivyBridge {
+  return {
+    login: async () => ({ email: { address: 'user@example.com' } }),
+    getAccessToken: async () => 'privy-token',
+    getUser: async () => ({ email: { address: 'user@example.com' } }),
+    getEmbeddedWallet: async () => ({
+      id: 'wallet-1',
+      address: '0x1111111111111111111111111111111111111111',
+      chainType: 'ethereum',
+      walletClientType: 'embedded',
+    }),
+    signMessage: async () => ({ signature: '0xsig' }),
+    sendTransaction: async () => ({ hash: '0xhash' }),
+  };
+}
+
+describe('AuthSessionService', () => {
+  let service: AuthSessionService;
+  let httpMock: HttpTestingController;
+  let router: { navigateByUrl: jasmine.Spy };
+
+  beforeEach(() => {
+    delete window.craftscriptPrivy;
+    delete window.craftscriptPrivyConfig;
+    router = { navigateByUrl: jasmine.createSpy('navigateByUrl') };
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: Router, useValue: router }],
+    });
+
+    service = TestBed.inject(AuthSessionService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    delete window.craftscriptPrivy;
+    delete window.craftscriptPrivyConfig;
+  });
+
+  it('uses runtime auth config login methods', () => {
+    window.craftscriptPrivyConfig = {
+      privyAppId: 'privy-app-id',
+      loginMethods: ['email', 'passkey'],
+      walletOnboarding: {
+        embeddedWallet: true,
+        externalWalletBinding: true,
+      },
+    };
+
+    expect(service.enabledLoginMethods).toEqual(['email', 'passkey']);
+  });
+
+  it('logs in through the Privy bridge and creates a backend session', fakeAsync(() => {
+    window.craftscriptPrivy = bridge();
+    let resolvedSession: unknown;
+
+    service.login('email').then(session => {
+      resolvedSession = session;
+    });
+    flushMicrotasks();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/v1/auth/privy/session`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer privy-token');
+    expect(req.request.body).toEqual({
+      email: 'user@example.com',
+      authMethod: 'email',
+      wallet: {
+        privyWalletId: 'wallet-1',
+        address: '0x1111111111111111111111111111111111111111',
+        chainType: 'ethereum',
+        walletType: 'embedded',
+        isPrimary: true,
+      },
+    });
+    req.flush({
+      user: {
+        id: 'account-1',
+        privyUserId: 'did:privy:user-1',
+        sessionId: 'session-1',
+        email: 'user@example.com',
+        authMethod: 'email',
+      },
+      wallets: [],
+    });
+    flushMicrotasks();
+
+    expect(resolvedSession).toEqual({
+      user: {
+        id: 'account-1',
+        privyUserId: 'did:privy:user-1',
+        sessionId: 'session-1',
+        email: 'user@example.com',
+        authMethod: 'email',
+      },
+      wallets: [],
+    });
+    expect(service.session?.user.id).toBe('account-1');
+  }));
+
+  it('refreshes session and wallets using the Privy access token', fakeAsync(() => {
+    window.craftscriptPrivy = bridge();
+    let resolvedSession: unknown;
+
+    service.refresh().then(session => {
+      resolvedSession = session;
+    });
+    flushMicrotasks();
+
+    const me = httpMock.expectOne(`${environment.apiUrl}/api/v1/me`);
+    const wallets = httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets`);
+    expect(me.request.headers.get('Authorization')).toBe('Bearer privy-token');
+    expect(wallets.request.headers.get('Authorization')).toBe('Bearer privy-token');
+    me.flush({
+      user: {
+        id: 'account-1',
+        privyUserId: 'did:privy:user-1',
+        sessionId: 'session-1',
+      },
+    });
+    wallets.flush({ wallets: [] });
+    flushMicrotasks();
+
+    expect(resolvedSession).toEqual({
+      user: {
+        id: 'account-1',
+        privyUserId: 'did:privy:user-1',
+        sessionId: 'session-1',
+      },
+      wallets: [],
+    });
+  }));
+});

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -82,6 +82,7 @@ describe('AuthSessionService', () => {
         address: '0x1111111111111111111111111111111111111111',
         chainType: 'ethereum',
         walletType: 'embedded',
+        source: 'privy',
         isPrimary: true,
       },
     });
@@ -141,5 +142,116 @@ describe('AuthSessionService', () => {
       },
       wallets: [],
     });
+  }));
+
+  it('sets a primary wallet and reloads wallet state', fakeAsync(() => {
+    window.craftscriptPrivy = bridge();
+    service.refresh();
+    flushMicrotasks();
+
+    httpMock.expectOne(`${environment.apiUrl}/api/v1/me`).flush({
+      user: {
+        id: 'account-1',
+        privyUserId: 'did:privy:user-1',
+        sessionId: 'session-1',
+      },
+    });
+    httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets`).flush({
+      wallets: [
+        {
+          id: 'wallet-1',
+          privyWalletId: 'wallet-1',
+          address: '0x1111111111111111111111111111111111111111',
+          chainType: 'ethereum',
+          walletType: 'embedded',
+          source: 'privy',
+          status: 'active',
+          isPrimary: false,
+          deletedAt: null,
+        },
+      ],
+    });
+    flushMicrotasks();
+
+    service.setPrimaryWallet('wallet-1');
+    flushMicrotasks();
+
+    const setPrimary = httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets/wallet-1/primary`);
+    expect(setPrimary.request.method).toBe('PATCH');
+    expect(setPrimary.request.headers.get('Authorization')).toBe('Bearer privy-token');
+    setPrimary.flush({
+      wallet: {
+        id: 'wallet-1',
+        privyWalletId: 'wallet-1',
+        address: '0x1111111111111111111111111111111111111111',
+        chainType: 'ethereum',
+        walletType: 'embedded',
+        source: 'privy',
+        status: 'active',
+        isPrimary: true,
+        deletedAt: null,
+      },
+    });
+    flushMicrotasks();
+    const reload = httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets`);
+    reload.flush({
+      wallets: [
+        {
+          id: 'wallet-1',
+          privyWalletId: 'wallet-1',
+          address: '0x1111111111111111111111111111111111111111',
+          chainType: 'ethereum',
+          walletType: 'embedded',
+          source: 'privy',
+          status: 'active',
+          isPrimary: true,
+          deletedAt: null,
+        },
+      ],
+    });
+    flushMicrotasks();
+
+    expect(service.session?.wallets[0].isPrimary).toBeTrue();
+  }));
+
+  it('deletes a wallet and reloads wallet state', fakeAsync(() => {
+    window.craftscriptPrivy = bridge();
+    service.refresh();
+    flushMicrotasks();
+
+    httpMock.expectOne(`${environment.apiUrl}/api/v1/me`).flush({
+      user: {
+        id: 'account-1',
+        privyUserId: 'did:privy:user-1',
+        sessionId: 'session-1',
+      },
+    });
+    httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets`).flush({
+      wallets: [
+        {
+          id: 'wallet-1',
+          privyWalletId: 'wallet-1',
+          address: '0x1111111111111111111111111111111111111111',
+          chainType: 'ethereum',
+          walletType: 'embedded',
+          isPrimary: true,
+        },
+      ],
+    });
+    flushMicrotasks();
+
+    service.deleteWallet('wallet-1');
+    flushMicrotasks();
+
+    const deleted = httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets/wallet-1`);
+    expect(deleted.request.method).toBe('DELETE');
+    expect(deleted.request.headers.get('Authorization')).toBe('Bearer privy-token');
+    deleted.flush({});
+    flushMicrotasks();
+    const reload = httpMock.expectOne(`${environment.apiUrl}/api/v1/wallets`);
+    reload.flush({ wallets: [] });
+    flushMicrotasks();
+
+    expect(service.session?.wallets).toEqual([]);
   }));
 });

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -254,4 +254,57 @@ describe('AuthSessionService', () => {
 
     expect(service.session?.wallets).toEqual([]);
   }));
+
+  it('loads balances using the Privy access token', fakeAsync(() => {
+    window.craftscriptPrivy = bridge();
+    let resolvedBalances: unknown;
+
+    service.loadBalances().then(balances => {
+      resolvedBalances = balances;
+    });
+    flushMicrotasks();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/v1/balances`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer privy-token');
+    req.flush({
+      data: [
+        {
+          walletId: 'wallet-1',
+          walletAddress: '0x1111111111111111111111111111111111111111',
+          chainType: 'near',
+          assetId: 'nep141:usdc.near',
+          symbol: 'USDC',
+          decimals: 6,
+          balanceRaw: '1250000',
+          balanceDecimal: '1.25',
+          source: 'postgres_cache',
+          fetchedAt: '2026-06-23T12:00:00.000Z',
+          expiresAt: '2026-06-23T12:01:00.000Z',
+        },
+      ],
+      meta: {
+        source: 'postgres_cache',
+        cached: true,
+        fetchedAt: '2026-06-23T12:00:00.000Z',
+      },
+    });
+    flushMicrotasks();
+
+    expect(resolvedBalances).toEqual([
+      {
+        walletId: 'wallet-1',
+        walletAddress: '0x1111111111111111111111111111111111111111',
+        chainType: 'near',
+        assetId: 'nep141:usdc.near',
+        symbol: 'USDC',
+        decimals: 6,
+        balanceRaw: '1250000',
+        balanceDecimal: '1.25',
+        source: 'postgres_cache',
+        fetchedAt: '2026-06-23T12:00:00.000Z',
+        expiresAt: '2026-06-23T12:01:00.000Z',
+      },
+    ]);
+  }));
 });

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -1,0 +1,150 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { Router } from '@angular/router';
+import { environment } from '../../../environments/environment';
+import type { PublicAuthConfig } from '@core/privy/privy-bridge.types';
+import {
+  AuthSession,
+  BackendUser,
+  BackendWallet,
+  emailFromPrivyUser,
+  LoginMethod,
+  PrivySessionRequest,
+  walletFromPrivyWallet,
+} from './auth-session.types';
+
+type MeResponse = {
+  user: BackendUser;
+};
+
+type WalletsResponse = {
+  wallets: BackendWallet[];
+};
+
+@Injectable({ providedIn: 'root' })
+export class AuthSessionService {
+  private readonly sessionSubject = new BehaviorSubject<AuthSession | null>(null);
+  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
+  private accessToken: string | null = null;
+
+  readonly session$ = this.sessionSubject.asObservable();
+  readonly loading$ = this.loadingSubject.asObservable();
+
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly router: Router
+  ) {}
+
+  get session(): AuthSession | null {
+    return this.sessionSubject.value;
+  }
+
+  get config(): PublicAuthConfig | undefined {
+    return window.craftscriptPrivyConfig;
+  }
+
+  get bridgeReady(): boolean {
+    return Boolean(window.craftscriptPrivy);
+  }
+
+  get enabledLoginMethods(): LoginMethod[] {
+    const methods = this.config?.loginMethods ?? [];
+    return methods.length > 0 ? methods : ['email'];
+  }
+
+  async refresh(): Promise<AuthSession | null> {
+    const token = await this.currentAccessToken();
+    if (!token) {
+      this.sessionSubject.next(null);
+      return null;
+    }
+
+    try {
+      const headers = this.authHeaders(token);
+      const [me, wallets] = await Promise.all([
+        firstValueFrom(this.httpClient.get<MeResponse>(`${environment.apiUrl}/api/v1/me`, { headers })),
+        firstValueFrom(this.httpClient.get<WalletsResponse>(`${environment.apiUrl}/api/v1/wallets`, { headers })),
+      ]);
+      const session = { user: me.user, wallets: wallets.wallets };
+      this.sessionSubject.next(session);
+      return session;
+    } catch {
+      this.sessionSubject.next(null);
+      return null;
+    }
+  }
+
+  async login(authMethod: LoginMethod): Promise<AuthSession> {
+    const bridge = window.craftscriptPrivy;
+    if (!bridge) {
+      throw new Error('Privy bridge is not available');
+    }
+
+    this.loadingSubject.next(true);
+    try {
+      const loginUser = await bridge.login();
+      const token = await bridge.getAccessToken();
+      if (!token) {
+        throw new Error('Privy access token is unavailable');
+      }
+      this.accessToken = token;
+
+      const [currentUser, embeddedWallet] = await Promise.all([
+        bridge.getUser().catch(() => null),
+        bridge.getEmbeddedWallet().catch(() => null),
+      ]);
+      const body: PrivySessionRequest = {
+        email: emailFromPrivyUser(currentUser || loginUser),
+        authMethod,
+        wallet: walletFromPrivyWallet(embeddedWallet),
+      };
+
+      const session = await firstValueFrom(
+        this.httpClient.post<AuthSession>(`${environment.apiUrl}/api/v1/auth/privy/session`, body, {
+          headers: this.authHeaders(token),
+        })
+      );
+      this.sessionSubject.next(session);
+      return session;
+    } finally {
+      this.loadingSubject.next(false);
+    }
+  }
+
+  async requestDeletion(): Promise<string> {
+    const token = await this.currentAccessToken();
+    if (!token) {
+      throw new Error('No active session');
+    }
+
+    const response = await firstValueFrom(
+      this.httpClient.delete<{ status: string; deletionAvailableAt: string }>(
+        `${environment.apiUrl}/api/v1/me`,
+        { headers: this.authHeaders(token) }
+      )
+    );
+    this.sessionSubject.next(null);
+    await this.router.navigateByUrl('/login');
+    return response.deletionAvailableAt;
+  }
+
+  clear(): void {
+    this.accessToken = null;
+    this.sessionSubject.next(null);
+  }
+
+  private async currentAccessToken(): Promise<string | null> {
+    if (this.accessToken) {
+      return this.accessToken;
+    }
+
+    const token = await window.craftscriptPrivy?.getAccessToken().catch(() => null);
+    this.accessToken = token ?? null;
+    return this.accessToken;
+  }
+
+  private authHeaders(token: string): HttpHeaders {
+    return new HttpHeaders({ Authorization: `Bearer ${token}` });
+  }
+}

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -22,6 +22,10 @@ type WalletsResponse = {
   wallets: BackendWallet[];
 };
 
+type WalletResponse = {
+  wallet: BackendWallet;
+};
+
 @Injectable({ providedIn: 'root' })
 export class AuthSessionService {
   private readonly sessionSubject = new BehaviorSubject<AuthSession | null>(null);
@@ -129,9 +133,63 @@ export class AuthSessionService {
     return response.deletionAvailableAt;
   }
 
+  async reloadWallets(): Promise<BackendWallet[]> {
+    const token = await this.currentAccessToken();
+    if (!token) {
+      throw new Error('No active session');
+    }
+
+    const response = await firstValueFrom(
+      this.httpClient.get<WalletsResponse>(`${environment.apiUrl}/api/v1/wallets`, {
+        headers: this.authHeaders(token),
+      })
+    );
+    this.updateWallets(response.wallets);
+    return response.wallets;
+  }
+
+  async setPrimaryWallet(walletId: string): Promise<BackendWallet> {
+    const token = await this.currentAccessToken();
+    if (!token) {
+      throw new Error('No active session');
+    }
+
+    const response = await firstValueFrom(
+      this.httpClient.patch<WalletResponse>(
+        `${environment.apiUrl}/api/v1/wallets/${walletId}/primary`,
+        {},
+        { headers: this.authHeaders(token) }
+      )
+    );
+    await this.reloadWallets();
+    return response.wallet;
+  }
+
+  async deleteWallet(walletId: string): Promise<void> {
+    const token = await this.currentAccessToken();
+    if (!token) {
+      throw new Error('No active session');
+    }
+
+    await firstValueFrom(
+      this.httpClient.delete(`${environment.apiUrl}/api/v1/wallets/${walletId}`, {
+        headers: this.authHeaders(token),
+      })
+    );
+    await this.reloadWallets();
+  }
+
   clear(): void {
     this.accessToken = null;
     this.sessionSubject.next(null);
+  }
+
+  private updateWallets(wallets: BackendWallet[]): void {
+    const session = this.sessionSubject.value;
+    if (!session) {
+      return;
+    }
+    this.sessionSubject.next({ ...session, wallets });
   }
 
   private async currentAccessToken(): Promise<string | null> {

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../../environments/environment';
 import type { PublicAuthConfig } from '@core/privy/privy-bridge.types';
 import {
   AuthSession,
+  BackendBalance,
   BackendUser,
   BackendWallet,
   emailFromPrivyUser,
@@ -24,6 +25,10 @@ type WalletsResponse = {
 
 type WalletResponse = {
   wallet: BackendWallet;
+};
+
+type BalancesResponse = {
+  data: BackendBalance[];
 };
 
 @Injectable({ providedIn: 'root' })
@@ -177,6 +182,21 @@ export class AuthSessionService {
       })
     );
     await this.reloadWallets();
+  }
+
+  async loadBalances(walletId?: string): Promise<BackendBalance[]> {
+    const token = await this.currentAccessToken();
+    if (!token) {
+      throw new Error('No active session');
+    }
+
+    const response = await firstValueFrom(
+      this.httpClient.get<BalancesResponse>(`${environment.apiUrl}/api/v1/balances`, {
+        headers: this.authHeaders(token),
+        params: walletId ? { walletId } : {},
+      })
+    );
+    return response.data ?? [];
   }
 
   clear(): void {

--- a/src/app/core/auth/auth-session.types.ts
+++ b/src/app/core/auth/auth-session.types.ts
@@ -14,7 +14,10 @@ export type BackendWallet = {
   address: string;
   chainType: string;
   walletType: string;
+  source?: string;
+  status?: string;
   isPrimary: boolean;
+  deletedAt?: string | null;
 };
 
 export type AuthSession = {
@@ -32,6 +35,7 @@ export type PrivySessionRequest = {
     address: string;
     chainType?: string;
     walletType?: string;
+    source?: string;
     isPrimary?: boolean;
   };
 };
@@ -50,6 +54,7 @@ export function walletFromPrivyWallet(wallet: PrivyEmbeddedWallet | null): Privy
     address: wallet.address,
     chainType: wallet.chainType || 'ethereum',
     walletType: wallet.walletClientType || 'embedded',
+    source: 'privy',
     isPrimary: true,
   };
 }

--- a/src/app/core/auth/auth-session.types.ts
+++ b/src/app/core/auth/auth-session.types.ts
@@ -1,0 +1,55 @@
+import type { PrivyBridgeUser, PrivyEmbeddedWallet } from '@core/privy/privy-bridge.types';
+
+export type BackendUser = {
+  id: string;
+  privyUserId: string;
+  sessionId: string;
+  email?: string | null;
+  authMethod?: string | null;
+};
+
+export type BackendWallet = {
+  id: string;
+  privyWalletId: string;
+  address: string;
+  chainType: string;
+  walletType: string;
+  isPrimary: boolean;
+};
+
+export type AuthSession = {
+  user: BackendUser;
+  wallets: BackendWallet[];
+};
+
+export type LoginMethod = 'email' | 'google' | 'apple' | 'passkey';
+
+export type PrivySessionRequest = {
+  email?: string;
+  authMethod?: string;
+  wallet?: {
+    privyWalletId?: string;
+    address: string;
+    chainType?: string;
+    walletType?: string;
+    isPrimary?: boolean;
+  };
+};
+
+export function emailFromPrivyUser(user: PrivyBridgeUser | null | void): string | undefined {
+  return user?.email?.address || undefined;
+}
+
+export function walletFromPrivyWallet(wallet: PrivyEmbeddedWallet | null): PrivySessionRequest['wallet'] {
+  if (!wallet?.address) {
+    return undefined;
+  }
+
+  return {
+    privyWalletId: wallet.id,
+    address: wallet.address,
+    chainType: wallet.chainType || 'ethereum',
+    walletType: wallet.walletClientType || 'embedded',
+    isPrimary: true,
+  };
+}

--- a/src/app/core/auth/auth-session.types.ts
+++ b/src/app/core/auth/auth-session.types.ts
@@ -20,6 +20,20 @@ export type BackendWallet = {
   deletedAt?: string | null;
 };
 
+export type BackendBalance = {
+  walletId: string;
+  walletAddress: string;
+  chainType: string;
+  assetId: string;
+  symbol: string;
+  decimals: number;
+  balanceRaw: string;
+  balanceDecimal?: string | null;
+  source: string;
+  fetchedAt: string;
+  expiresAt: string;
+};
+
 export type AuthSession = {
   user: BackendUser;
   wallets: BackendWallet[];

--- a/src/app/core/auth/auth.guard.ts
+++ b/src/app/core/auth/auth.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthSessionService } from './auth-session.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(
+    private readonly authSession: AuthSessionService,
+    private readonly router: Router
+  ) {}
+
+  async canActivate(): Promise<boolean | UrlTree> {
+    if (this.authSession.session) {
+      return true;
+    }
+
+    const session = await this.authSession.refresh();
+    return session ? true : this.router.parseUrl('/login');
+  }
+}

--- a/src/app/core/privy/privy-bridge.service.spec.ts
+++ b/src/app/core/privy/privy-bridge.service.spec.ts
@@ -1,0 +1,136 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { PrivyBridgeService } from './privy-bridge.service';
+import { environment } from '../../../environments/environment';
+import type { CraftscriptPrivyBridge } from './privy-bridge.types';
+import { PRIVY_SOURCE_READY_EVENT } from './privy-host-bridge';
+
+function bridge(): CraftscriptPrivyBridge {
+  return {
+    login: async () => undefined,
+    getAccessToken: async () => null,
+    getUser: async () => null,
+    getEmbeddedWallet: async () => null,
+    signMessage: async () => ({ signature: '0xsig' }),
+    sendTransaction: async () => ({ hash: '0xhash' }),
+  };
+}
+
+describe('PrivyBridgeService', () => {
+  let service: PrivyBridgeService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    delete window.craftscriptPrivy;
+    delete window.craftscriptPrivySource;
+    delete window.craftscriptPrivyConfig;
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+
+    service = TestBed.inject(PrivyBridgeService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    service.ngOnDestroy();
+    httpMock.verify();
+    delete window.craftscriptPrivy;
+    delete window.craftscriptPrivySource;
+    delete window.craftscriptPrivyConfig;
+  });
+
+  it('fetches and exposes enabled public Privy config', async () => {
+    const initialized = service.initialize();
+
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/api/v1/public/auth-config`
+    );
+    req.flush({
+      privyAppId: 'privy-app-id',
+      loginMethods: ['email', 'google', 'passkey'],
+      walletOnboarding: {
+        embeddedWallet: true,
+        externalWalletBinding: true,
+      },
+    });
+
+    await initialized;
+
+    expect(window.craftscriptPrivyConfig).toEqual({
+      privyAppId: 'privy-app-id',
+      loginMethods: ['email', 'google', 'passkey'],
+      walletOnboarding: {
+        embeddedWallet: true,
+        externalWalletBinding: true,
+      },
+    });
+  });
+
+  it('does not expose disabled public Privy config', async () => {
+    const initialized = service.initialize();
+
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/api/v1/public/auth-config`
+    );
+    req.flush({
+      privyAppId: null,
+      loginMethods: [],
+      walletOnboarding: {
+        embeddedWallet: false,
+        externalWalletBinding: false,
+      },
+    });
+
+    await initialized;
+
+    expect(window.craftscriptPrivyConfig).toBeUndefined();
+  });
+
+  it('adopts an existing Privy bridge source', async () => {
+    const source = bridge();
+    window.craftscriptPrivySource = source;
+
+    const initialized = service.initialize();
+    httpMock
+      .expectOne(`${environment.apiUrl}/api/v1/public/auth-config`)
+      .flush({
+        privyAppId: null,
+        loginMethods: [],
+        walletOnboarding: {
+          embeddedWallet: false,
+          externalWalletBinding: false,
+        },
+      });
+
+    await initialized;
+
+    expect(window.craftscriptPrivy).toBe(source);
+  });
+
+  it('adopts a Privy bridge source that becomes ready after startup', async () => {
+    const initialized = service.initialize();
+    httpMock
+      .expectOne(`${environment.apiUrl}/api/v1/public/auth-config`)
+      .flush({
+        privyAppId: 'privy-app-id',
+        loginMethods: ['email'],
+        walletOnboarding: {
+          embeddedWallet: true,
+          externalWalletBinding: true,
+        },
+      });
+
+    await initialized;
+
+    const source = bridge();
+    window.craftscriptPrivySource = source;
+    window.dispatchEvent(new Event(PRIVY_SOURCE_READY_EVENT));
+
+    expect(window.craftscriptPrivy).toBe(source);
+  });
+});

--- a/src/app/core/privy/privy-bridge.service.ts
+++ b/src/app/core/privy/privy-bridge.service.ts
@@ -1,13 +1,69 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { resolvePrivyHostBridge } from './privy-host-bridge';
-import type { CraftscriptPrivyBridge } from './privy-bridge.types';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom, timeout } from 'rxjs';
+import {
+  PRIVY_SOURCE_READY_EVENT,
+  resolvePrivyHostBridge,
+} from './privy-host-bridge';
+import type {
+  CraftscriptPrivyBridge,
+  PublicAuthConfig,
+} from './privy-bridge.types';
+import { environment } from '../../../environments/environment';
 import './privy-bridge.types';
 
 @Injectable({ providedIn: 'root' })
 export class PrivyBridgeService implements OnDestroy {
   private assignedBridge: CraftscriptPrivyBridge | undefined;
+  private assignedConfig = false;
+  private listeningForSource = false;
 
-  initialize(): void {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async initialize(): Promise<void> {
+    this.listenForSource();
+    this.mountBridge();
+
+    const config = await this.fetchPublicAuthConfig();
+    if (this.isPrivyEnabled(config)) {
+      window.craftscriptPrivyConfig = config;
+      this.assignedConfig = true;
+      this.mountBridge();
+    }
+  }
+
+  private async fetchPublicAuthConfig(): Promise<PublicAuthConfig | null> {
+    try {
+      return await firstValueFrom(
+        this.httpClient.get<PublicAuthConfig>(
+          `${environment.apiUrl}/api/v1/public/auth-config`
+        ).pipe(timeout(3000))
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  private isPrivyEnabled(
+    config: PublicAuthConfig | null
+  ): config is PublicAuthConfig {
+    return Boolean(config?.privyAppId?.trim());
+  }
+
+  private listenForSource(): void {
+    if (this.listeningForSource) {
+      return;
+    }
+
+    window.addEventListener(PRIVY_SOURCE_READY_EVENT, this.sourceReadyListener);
+    this.listeningForSource = true;
+  }
+
+  private readonly sourceReadyListener = () => {
+    this.mountBridge();
+  };
+
+  private mountBridge(): void {
     const bridge = resolvePrivyHostBridge();
     if (!bridge || window.craftscriptPrivy === bridge) {
       return;
@@ -18,6 +74,14 @@ export class PrivyBridgeService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (this.listeningForSource) {
+      window.removeEventListener(
+        PRIVY_SOURCE_READY_EVENT,
+        this.sourceReadyListener
+      );
+      this.listeningForSource = false;
+    }
+
     if (
       this.assignedBridge &&
       window.craftscriptPrivy === this.assignedBridge
@@ -26,5 +90,10 @@ export class PrivyBridgeService implements OnDestroy {
     }
 
     this.assignedBridge = undefined;
+
+    if (this.assignedConfig) {
+      delete window.craftscriptPrivyConfig;
+      this.assignedConfig = false;
+    }
   }
 }

--- a/src/app/core/privy/privy-bridge.types.ts
+++ b/src/app/core/privy/privy-bridge.types.ts
@@ -32,10 +32,21 @@ export type CraftscriptPrivyBridge = {
   }) => Promise<{ hash: string }>;
 };
 
+export type PublicAuthLoginMethod = 'email' | 'google' | 'apple' | 'passkey';
+
+export type PublicAuthConfig = {
+  privyAppId: string | null;
+  loginMethods: PublicAuthLoginMethod[];
+  walletOnboarding: {
+    embeddedWallet: boolean;
+    externalWalletBinding: boolean;
+  };
+};
+
 declare global {
   interface Window {
     craftscriptPrivy?: CraftscriptPrivyBridge;
     craftscriptPrivySource?: CraftscriptPrivyBridge;
+    craftscriptPrivyConfig?: PublicAuthConfig;
   }
 }
-

--- a/src/app/core/privy/privy-host-bridge.ts
+++ b/src/app/core/privy/privy-host-bridge.ts
@@ -1,5 +1,7 @@
 import type { CraftscriptPrivyBridge } from './privy-bridge.types';
 
+export const PRIVY_SOURCE_READY_EVENT = 'craftscript:privy-source-ready';
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/src/app/pages/auth/auth-routing.module.ts
+++ b/src/app/pages/auth/auth-routing.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './login/login.component';
+import { ProfileComponent } from './profile/profile.component';
+import { AuthGuard } from '@core/auth/auth.guard';
+
+const routes: Routes = [
+  {
+    path: 'login',
+    component: LoginComponent,
+  },
+  {
+    path: 'profile',
+    component: ProfileComponent,
+    canActivate: [AuthGuard],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AuthRoutingModule {}

--- a/src/app/pages/auth/auth.module.ts
+++ b/src/app/pages/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { SharedModule } from '@shared/shared.module';
+import { AuthRoutingModule } from './auth-routing.module';
+import { LoginComponent } from './login/login.component';
+import { ProfileComponent } from './profile/profile.component';
+
+@NgModule({
+  imports: [SharedModule, AuthRoutingModule],
+  declarations: [LoginComponent, ProfileComponent],
+})
+export class AuthModule {}

--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -1,0 +1,29 @@
+<section class="login-shell">
+  <div class="login-shell__panel">
+    <div class="login-shell__heading">
+      <p class="login-shell__eyebrow">CraftScript Account</p>
+      <h1>Sign in</h1>
+    </div>
+
+    <div class="login-shell__status" *ngIf="!authSession.config">
+      Account login is not enabled for this environment.
+    </div>
+
+    <div class="login-shell__status" *ngIf="authSession.config && !authSession.bridgeReady">
+      Account provider is still starting.
+    </div>
+
+    <div class="login-shell__actions" *ngIf="authSession.config">
+      <button
+        *ngFor="let method of loginMethods"
+        type="button"
+        mat-stroked-button
+        [disabled]="!authSession.bridgeReady || (authSession.loading$ | async)"
+        (click)="login(method)">
+        {{ labelFor(method) }}
+      </button>
+    </div>
+
+    <p class="login-shell__error" *ngIf="error">{{ error }}</p>
+  </div>
+</section>

--- a/src/app/pages/auth/login/login.component.scss
+++ b/src/app/pages/auth/login/login.component.scss
@@ -1,0 +1,68 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.login-shell {
+  display: grid;
+  min-height: calc(100vh - var(--shell-header-height));
+  align-items: start;
+  padding: clamp(1rem, 3vw, 2rem);
+
+  &__panel {
+    display: grid;
+    width: min(100%, 34rem);
+    padding: 1rem;
+    border: 1px solid rgb(255 255 255 / 14%);
+    border-radius: 8px;
+    background: rgb(255 255 255 / 3%);
+    gap: 1rem;
+  }
+
+  &__heading {
+    display: grid;
+    gap: 0.35rem;
+
+    h1 {
+      margin: 0;
+      font-size: 1.6rem;
+      font-weight: 600;
+      line-height: 1.2;
+    }
+  }
+
+  &__eyebrow {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
+  &__status,
+  &__error {
+    color: var(--gray-30);
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+
+  &__error {
+    color: #ffb085;
+  }
+
+  &__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+
+    button {
+      min-height: 2.75rem;
+    }
+  }
+}
+
+@media (width <= 520px) {
+  .login-shell {
+    &__actions {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/src/app/pages/auth/login/login.component.ts
+++ b/src/app/pages/auth/login/login.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import type { LoginMethod } from '@core/auth/auth-session.types';
+
+const LOGIN_LABELS: Record<LoginMethod, string> = {
+  email: 'Email',
+  google: 'Google',
+  apple: 'Apple',
+  passkey: 'Passkey',
+};
+
+@Component({
+  selector: 'app-login',
+  standalone: false,
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss'],
+})
+export class LoginComponent {
+  public error = '';
+
+  constructor(
+    public readonly authSession: AuthSessionService,
+    private readonly router: Router
+  ) {}
+
+  public get loginMethods(): LoginMethod[] {
+    return this.authSession.enabledLoginMethods;
+  }
+
+  public labelFor(method: LoginMethod): string {
+    return LOGIN_LABELS[method];
+  }
+
+  public async login(method: LoginMethod): Promise<void> {
+    this.error = '';
+    try {
+      await this.authSession.login(method);
+      await this.router.navigateByUrl('/profile');
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Login failed';
+    }
+  }
+}

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -29,19 +29,46 @@
     </section>
 
     <section class="profile-shell__panel">
-      <h2>Wallets</h2>
+      <div class="profile-shell__panel-header">
+        <h2>Wallets</h2>
+        <button type="button" mat-button (click)="refreshWallets()">
+          Refresh
+        </button>
+      </div>
+      <app-wallet-bar />
       <div class="profile-shell__empty" *ngIf="activeSession.wallets.length === 0">
         No wallet linked.
       </div>
       <ul class="profile-shell__wallets" *ngIf="activeSession.wallets.length > 0">
         <li *ngFor="let wallet of activeSession.wallets">
-          <span>{{ shortAddress(wallet.address) }}</span>
-          <small>{{ wallet.chainType }} / {{ wallet.walletType }}</small>
+          <div class="profile-shell__wallet-main">
+            <span>{{ shortAddress(wallet.address) }}</span>
+            <small>{{ walletMeta(wallet) }}</small>
+          </div>
+          <div class="profile-shell__wallet-actions">
+            <span class="profile-shell__primary" *ngIf="wallet.isPrimary">Active</span>
+            <button
+              type="button"
+              mat-button
+              *ngIf="!wallet.isPrimary"
+              [disabled]="busyWalletId === wallet.id"
+              (click)="setPrimaryWallet(wallet)">
+              Make active
+            </button>
+            <button
+              type="button"
+              mat-button
+              [disabled]="busyWalletId === wallet.id"
+              (click)="deleteWallet(wallet)">
+              Remove
+            </button>
+          </div>
         </li>
       </ul>
     </section>
   </div>
 
+  <p class="profile-shell__message" *ngIf="walletMessage">{{ walletMessage }}</p>
   <p class="profile-shell__message" *ngIf="deletionMessage">{{ deletionMessage }}</p>
   <p class="profile-shell__error" *ngIf="error">{{ error }}</p>
 </section>

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -66,9 +66,41 @@
         </li>
       </ul>
     </section>
+
+    <section class="profile-shell__panel profile-shell__panel--wide">
+      <div class="profile-shell__panel-header">
+        <h2>Balances</h2>
+        <button
+          type="button"
+          mat-button
+          [disabled]="balancesLoading"
+          (click)="refreshBalances()">
+          Refresh
+        </button>
+      </div>
+      <div class="profile-shell__empty" *ngIf="balancesLoading">
+        Loading balances...
+      </div>
+      <div class="profile-shell__empty" *ngIf="!balancesLoading && balances.length === 0">
+        No cached balances yet.
+      </div>
+      <ul class="profile-shell__balances" *ngIf="!balancesLoading && balances.length > 0">
+        <li *ngFor="let balance of balances">
+          <div class="profile-shell__balance-asset">
+            <span>{{ balance.symbol }}</span>
+            <small>{{ balance.assetId }}</small>
+          </div>
+          <div class="profile-shell__balance-value">
+            <span>{{ balanceAmount(balance) }}</span>
+            <small>{{ balanceMeta(balance) }}</small>
+          </div>
+        </li>
+      </ul>
+    </section>
   </div>
 
   <p class="profile-shell__message" *ngIf="walletMessage">{{ walletMessage }}</p>
+  <p class="profile-shell__message" *ngIf="balanceMessage">{{ balanceMessage }}</p>
   <p class="profile-shell__message" *ngIf="deletionMessage">{{ deletionMessage }}</p>
   <p class="profile-shell__error" *ngIf="error">{{ error }}</p>
 </section>

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -1,0 +1,47 @@
+<section class="profile-shell" *ngIf="session as activeSession">
+  <div class="profile-shell__header">
+    <div>
+      <p class="profile-shell__eyebrow">Profile</p>
+      <h1>{{ activeSession.user.email || activeSession.user.privyUserId }}</h1>
+    </div>
+    <button type="button" mat-stroked-button (click)="requestDeletion()">
+      Request deletion
+    </button>
+  </div>
+
+  <div class="profile-shell__grid">
+    <section class="profile-shell__panel">
+      <h2>Account</h2>
+      <dl>
+        <div>
+          <dt>Account ID</dt>
+          <dd>{{ activeSession.user.id }}</dd>
+        </div>
+        <div>
+          <dt>Privy subject</dt>
+          <dd>{{ activeSession.user.privyUserId }}</dd>
+        </div>
+        <div>
+          <dt>Auth method</dt>
+          <dd>{{ activeSession.user.authMethod || 'Privy' }}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="profile-shell__panel">
+      <h2>Wallets</h2>
+      <div class="profile-shell__empty" *ngIf="activeSession.wallets.length === 0">
+        No wallet linked.
+      </div>
+      <ul class="profile-shell__wallets" *ngIf="activeSession.wallets.length > 0">
+        <li *ngFor="let wallet of activeSession.wallets">
+          <span>{{ shortAddress(wallet.address) }}</span>
+          <small>{{ wallet.chainType }} / {{ wallet.walletType }}</small>
+        </li>
+      </ul>
+    </section>
+  </div>
+
+  <p class="profile-shell__message" *ngIf="deletionMessage">{{ deletionMessage }}</p>
+  <p class="profile-shell__error" *ngIf="error">{{ error }}</p>
+</section>

--- a/src/app/pages/auth/profile/profile.component.scss
+++ b/src/app/pages/auth/profile/profile.component.scss
@@ -50,6 +50,17 @@
     }
   }
 
+  &__panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+
+    h2 {
+      margin-bottom: 0;
+    }
+  }
+
   dl {
     display: grid;
     margin: 0;
@@ -93,6 +104,26 @@
     }
   }
 
+  &__wallet-main {
+    display: grid;
+    min-width: 0;
+    gap: 0.15rem;
+  }
+
+  &__wallet-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+  }
+
+  &__primary {
+    color: var(--success, #7ee787);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
   &__empty,
   &__message,
   &__error {
@@ -121,6 +152,10 @@
       align-items: flex-start;
       flex-direction: column;
       gap: 0.15rem;
+    }
+
+    &__wallet-actions {
+      justify-content: flex-start;
     }
   }
 }

--- a/src/app/pages/auth/profile/profile.component.scss
+++ b/src/app/pages/auth/profile/profile.component.scss
@@ -48,6 +48,10 @@
       font-size: 1rem;
       font-weight: 600;
     }
+
+    &--wide {
+      grid-column: 1 / -1;
+    }
   }
 
   &__panel-header {
@@ -118,6 +122,50 @@
     gap: 0.35rem;
   }
 
+  &__balances {
+    display: grid;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    gap: 0.65rem;
+
+    li {
+      display: grid;
+      min-width: 0;
+      align-items: center;
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+      gap: 1rem;
+      padding: 0.7rem 0;
+      border-top: 1px solid rgb(255 255 255 / 10%);
+
+      &:first-child {
+        border-top: 0;
+      }
+    }
+  }
+
+  &__balance-asset,
+  &__balance-value {
+    display: grid;
+    min-width: 0;
+    gap: 0.15rem;
+
+    span,
+    small {
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__balance-value {
+    justify-items: end;
+    text-align: right;
+
+    span {
+      color: var(--gray-30);
+      font-weight: 600;
+    }
+  }
+
   &__primary {
     color: var(--success, #7ee787);
     font-size: 0.78rem;
@@ -156,6 +204,16 @@
 
     &__wallet-actions {
       justify-content: flex-start;
+    }
+
+    &__balances li {
+      grid-template-columns: 1fr;
+      gap: 0.35rem;
+    }
+
+    &__balance-value {
+      justify-items: start;
+      text-align: left;
     }
   }
 }

--- a/src/app/pages/auth/profile/profile.component.scss
+++ b/src/app/pages/auth/profile/profile.component.scss
@@ -1,0 +1,126 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.profile-shell {
+  display: grid;
+  padding: clamp(1rem, 3vw, 2rem);
+  gap: 1rem;
+
+  &__header {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    h1 {
+      overflow-wrap: anywhere;
+      margin: 0.25rem 0 0;
+      font-size: 1.35rem;
+      font-weight: 600;
+      line-height: 1.25;
+    }
+  }
+
+  &__eyebrow {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  &__panel {
+    min-width: 0;
+    padding: 1rem;
+    border: 1px solid rgb(255 255 255 / 14%);
+    border-radius: 8px;
+    background: rgb(255 255 255 / 3%);
+
+    h2 {
+      margin: 0 0 1rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+  }
+
+  dl {
+    display: grid;
+    margin: 0;
+    gap: 0.85rem;
+
+    div {
+      display: grid;
+      min-width: 0;
+      gap: 0.2rem;
+    }
+  }
+
+  dt,
+  small {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1.1rem;
+  }
+
+  dd {
+    overflow-wrap: anywhere;
+    margin: 0;
+    color: var(--gray-30);
+    font-size: 0.92rem;
+    line-height: 1.3;
+  }
+
+  &__wallets {
+    display: grid;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    gap: 0.65rem;
+
+    li {
+      display: flex;
+      min-width: 0;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+  }
+
+  &__empty,
+  &__message,
+  &__error {
+    color: var(--gray-30);
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+
+  &__error {
+    color: #ffb085;
+  }
+}
+
+@media (width <= 720px) {
+  .profile-shell {
+    &__header {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    &__grid {
+      grid-template-columns: 1fr;
+    }
+
+    &__wallets li {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.15rem;
+    }
+  }
+}

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -1,7 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AuthSessionService } from '@core/auth/auth-session.service';
-import type { AuthSession, BackendWallet } from '@core/auth/auth-session.types';
+import type {
+  AuthSession,
+  BackendBalance,
+  BackendWallet,
+} from '@core/auth/auth-session.types';
 
 @Component({
   selector: 'app-profile',
@@ -13,8 +17,11 @@ export class ProfileComponent implements OnInit, OnDestroy {
   public session: AuthSession | null = null;
   public deletionMessage = '';
   public walletMessage = '';
+  public balanceMessage = '';
   public error = '';
   public busyWalletId = '';
+  public balances: BackendBalance[] = [];
+  public balancesLoading = false;
 
   private subscription?: Subscription;
 
@@ -23,6 +30,11 @@ export class ProfileComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.subscription = this.authSession.session$.subscribe(session => {
       this.session = session;
+      if (session) {
+        void this.refreshBalances();
+      } else {
+        this.balances = [];
+      }
     });
   }
 
@@ -40,6 +52,19 @@ export class ProfileComponent implements OnInit, OnDestroy {
       .join(' / ');
   }
 
+  public balanceAmount(balance: BackendBalance): string {
+    const amount = balance.balanceDecimal || this.rawToDecimal(balance.balanceRaw, balance.decimals);
+    return `${amount} ${balance.symbol}`;
+  }
+
+  public balanceMeta(balance: BackendBalance): string {
+    const expiry = new Date(balance.expiresAt);
+    const expiresAt = Number.isNaN(expiry.getTime())
+      ? 'cache'
+      : `cache until ${expiry.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+    return `${this.shortAddress(balance.walletAddress)} / ${balance.chainType} / ${expiresAt}`;
+  }
+
   public async refreshWallets(): Promise<void> {
     this.error = '';
     this.walletMessage = '';
@@ -48,6 +73,20 @@ export class ProfileComponent implements OnInit, OnDestroy {
       this.walletMessage = 'Wallets refreshed';
     } catch (error) {
       this.error = error instanceof Error ? error.message : 'Wallet refresh failed';
+    }
+  }
+
+  public async refreshBalances(): Promise<void> {
+    this.error = '';
+    this.balanceMessage = '';
+    this.balancesLoading = true;
+    try {
+      this.balances = await this.authSession.loadBalances();
+      this.balanceMessage = this.balances.length > 0 ? 'Balances refreshed' : '';
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Balance refresh failed';
+    } finally {
+      this.balancesLoading = false;
     }
   }
 
@@ -92,5 +131,16 @@ export class ProfileComponent implements OnInit, OnDestroy {
     } catch (error) {
       this.error = error instanceof Error ? error.message : 'Account deletion failed';
     }
+  }
+
+  private rawToDecimal(rawBalance: string, decimals: number): string {
+    if (!/^\d+$/.test(rawBalance) || decimals <= 0) {
+      return rawBalance;
+    }
+
+    const padded = rawBalance.padStart(decimals + 1, '0');
+    const whole = padded.slice(0, -decimals);
+    const fraction = padded.slice(-decimals).replace(/0+$/, '');
+    return fraction ? `${whole}.${fraction}` : whole;
   }
 }

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import type { AuthSession } from '@core/auth/auth-session.types';
+
+@Component({
+  selector: 'app-profile',
+  standalone: false,
+  templateUrl: './profile.component.html',
+  styleUrls: ['./profile.component.scss'],
+})
+export class ProfileComponent implements OnInit, OnDestroy {
+  public session: AuthSession | null = null;
+  public deletionMessage = '';
+  public error = '';
+
+  private subscription?: Subscription;
+
+  constructor(public readonly authSession: AuthSessionService) {}
+
+  public ngOnInit(): void {
+    this.subscription = this.authSession.session$.subscribe(session => {
+      this.session = session;
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
+  public shortAddress(address: string): string {
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  }
+
+  public async requestDeletion(): Promise<void> {
+    this.error = '';
+    this.deletionMessage = '';
+    try {
+      const deletionAvailableAt = await this.authSession.requestDeletion();
+      this.deletionMessage = `Deletion available ${new Date(deletionAvailableAt).toLocaleDateString()}`;
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Account deletion failed';
+    }
+  }
+}

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AuthSessionService } from '@core/auth/auth-session.service';
-import type { AuthSession } from '@core/auth/auth-session.types';
+import type { AuthSession, BackendWallet } from '@core/auth/auth-session.types';
 
 @Component({
   selector: 'app-profile',
@@ -12,7 +12,9 @@ import type { AuthSession } from '@core/auth/auth-session.types';
 export class ProfileComponent implements OnInit, OnDestroy {
   public session: AuthSession | null = null;
   public deletionMessage = '';
+  public walletMessage = '';
   public error = '';
+  public busyWalletId = '';
 
   private subscription?: Subscription;
 
@@ -30,6 +32,55 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
   public shortAddress(address: string): string {
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  }
+
+  public walletMeta(wallet: BackendWallet): string {
+    return [wallet.chainType, wallet.walletType, wallet.source]
+      .filter(Boolean)
+      .join(' / ');
+  }
+
+  public async refreshWallets(): Promise<void> {
+    this.error = '';
+    this.walletMessage = '';
+    try {
+      await this.authSession.reloadWallets();
+      this.walletMessage = 'Wallets refreshed';
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Wallet refresh failed';
+    }
+  }
+
+  public async setPrimaryWallet(wallet: BackendWallet): Promise<void> {
+    if (wallet.isPrimary) {
+      return;
+    }
+
+    this.error = '';
+    this.walletMessage = '';
+    this.busyWalletId = wallet.id;
+    try {
+      await this.authSession.setPrimaryWallet(wallet.id);
+      this.walletMessage = `${this.shortAddress(wallet.address)} is now active`;
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Wallet activation failed';
+    } finally {
+      this.busyWalletId = '';
+    }
+  }
+
+  public async deleteWallet(wallet: BackendWallet): Promise<void> {
+    this.error = '';
+    this.walletMessage = '';
+    this.busyWalletId = wallet.id;
+    try {
+      await this.authSession.deleteWallet(wallet.id);
+      this.walletMessage = `${this.shortAddress(wallet.address)} removed`;
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Wallet removal failed';
+    } finally {
+      this.busyWalletId = '';
+    }
   }
 
   public async requestDeletion(): Promise<void> {

--- a/src/app/shared/mfe/wallets/wallets.component.ts
+++ b/src/app/shared/mfe/wallets/wallets.component.ts
@@ -15,6 +15,7 @@ import {
 } from '@mfe-contracts/wallet-mfe.types';
 import { WalletAccountChangedPayload } from '@mfe-contracts/payloads';
 import { AppLoggerService } from '@core/logging/app-logger.service';
+import { AuthSessionService } from '@core/auth/auth-session.service';
 import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
 import { environment } from '../../../../environments/environment';
 
@@ -35,6 +36,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
   constructor(
     private walletsService: WalletsService,
     private walletGatewayBridge: WalletGatewayBridgeService,
+    private authSession: AuthSessionService,
     private logger: AppLoggerService,
     private ngZone: NgZone
   ) {}
@@ -89,6 +91,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
                 account: account.account,
                 chainId: this.walletsService.account.value?.chainId ?? null,
               });
+              this.refreshBackendWallets();
             });
           },
           onCloseRequested: () => {
@@ -149,6 +152,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
         account: snapshot.account,
         chainId: snapshot.chainId,
       });
+      this.refreshBackendWallets();
       return;
     }
 
@@ -171,6 +175,20 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
 
   private mfeEnvironment(): 'dev' | 'prod' {
     return environment.production ? 'prod' : 'dev';
+  }
+
+  private refreshBackendWallets(): void {
+    if (!this.authSession.session) {
+      return;
+    }
+
+    void this.authSession.reloadWallets().catch(error => {
+      this.logger.log('warn', 'Wallets MFE: backend wallet refresh failed', {
+        component: 'WalletsComponent',
+        action: 'refreshBackendWallets',
+        errorMessage: this.errorMessage(error),
+      });
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
- Release the Angular Privy onboarding flow: runtime Privy bridge bootstrap, login/profile shell, route guarding, and authenticated session refresh.
- Add wallet management UI for linked Privy/external wallets, including refresh, active-wallet selection, and removal.
- Add cached balance display backed by the backend `/api/v1/balances` contract.

## Scope
- Frontend only. The client consumes backend-provided auth, wallet, and balance APIs.
- No Privy secrets, RPC credentials, or authoritative token/balance registry are exposed in the browser.

## Included PRs
- #102 `feat(auth): bootstrap Privy runtime bridge`
- #103 `feat(auth): add login and profile shell`
- #104 `feat(auth): add wallet management UI`
- #105 `feat(auth): show cached balances`
