### PR TITLE
release: integrate Privy register onboarding

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -174,6 +174,10 @@ CI (`/.github/workflows/build-dev.yml`) runs `pnpm run e2e` against a production
 - Host responsibility: shell layout, top-level routing, session bootstrap, telemetry, shared UX policies.
 - MFE responsibility (`mfe-wallets`): wallet domain pages, wallet domain workflows, wallet-specific state.
 - `mfe-wallets` also owns the browser account-provider instance because that instance performs passkey wallet discovery and wallet signing. The host consumes only the versioned session-facing API in `src/app/mfe-contracts/auth-provider.types.ts`.
+- The wallet remote is atomized. Angular loads `./mount` and `./auth-provider`;
+  `./providers/privy` remains a wallet-MFE-owned provider atom loaded by the
+  MFE only when Privy auth, embedded-wallet creation, or passkey signing needs
+  it.
 - Backend responsibility (NestJS): typed BFF APIs, aggregation/orchestration, normalized error model, observability boundaries.
 - Key rule: communication happens only through documented contracts (route/mount, typed data, versioned events).
 

--- a/src/app/core/auth/auth-provider.service.spec.ts
+++ b/src/app/core/auth/auth-provider.service.spec.ts
@@ -11,6 +11,9 @@ import {
   AuthProviderService,
 } from './auth-provider.service';
 import { AppLoggerService } from '@core/logging/app-logger.service';
+import {
+  WALLET_REMOTE_EXPOSED_MODULES,
+} from '@mfe-contracts/wallet-remote-entrypoints';
 
 function mountApi(
   initialSnapshot: AuthProviderSnapshot,
@@ -34,6 +37,7 @@ function mountApi(
       wallets: [],
     }),
     getAccessToken: async () => 'provider-token',
+    logout: async () => undefined,
   };
 }
 
@@ -75,6 +79,13 @@ describe('AuthProviderService', () => {
     expect(mountAuthProvider).toHaveBeenCalledWith(jasmine.any(HTMLElement), {
       apiBaseUrl: environment.apiUrl,
     });
+  });
+
+  it('keeps the host on the thin auth-provider atom', () => {
+    expect(WALLET_REMOTE_EXPOSED_MODULES.authProvider).toBe('./auth-provider');
+    expect(WALLET_REMOTE_EXPOSED_MODULES.privyProvider).toBe(
+      './providers/privy'
+    );
   });
 
   it('keeps late provider readiness observable', async () => {

--- a/src/app/core/auth/auth-provider.service.ts
+++ b/src/app/core/auth/auth-provider.service.ts
@@ -9,10 +9,13 @@ import {
   AuthProviderSession,
   AuthProviderSnapshot,
 } from '@mfe-contracts/auth-provider.types';
+import {
+  WALLET_REMOTE_EXPOSED_MODULES,
+  WALLET_REMOTE_NAME,
+} from '@mfe-contracts/wallet-remote-entrypoints';
 import { environment } from '../../../environments/environment';
 import { AppLoggerService } from '@core/logging/app-logger.service';
 
-const REMOTE_NAME = 'mfe-wallets';
 const REMOTE_LOAD_TIMEOUT_MS = 15_000;
 const INITIAL_SNAPSHOT: AuthProviderSnapshot = {
   status: 'loading',
@@ -28,8 +31,8 @@ export const AUTH_PROVIDER_REMOTE_LOADER =
     factory: () => () =>
       loadRemoteModule({
         type: 'manifest',
-        remoteName: REMOTE_NAME,
-        exposedModule: './auth-provider',
+        remoteName: WALLET_REMOTE_NAME,
+        exposedModule: WALLET_REMOTE_EXPOSED_MODULES.authProvider,
       }),
   });
 
@@ -66,6 +69,10 @@ export class AuthProviderService implements OnDestroy {
 
   login(method: AuthProviderLoginMethod): Promise<AuthProviderSession> {
     return this.requireReadyProvider().login(method);
+  }
+
+  logout(): Promise<void> {
+    return this.mountApi?.logout() ?? Promise.resolve();
   }
 
   getAccessToken(): Promise<string | null> {
@@ -213,6 +220,8 @@ export class AuthProviderService implements OnDestroy {
       typeof value.getSnapshot === 'function' &&
       'login' in value &&
       typeof value.login === 'function' &&
+      'logout' in value &&
+      typeof value.logout === 'function' &&
       'getAccessToken' in value &&
       typeof value.getAccessToken === 'function'
     );

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -7,18 +7,22 @@ import { Router } from '@angular/router';
 import { AuthSessionService } from './auth-session.service';
 import { environment } from '../../../environments/environment';
 import { AuthProviderService } from './auth-provider.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 
 describe('AuthSessionService', () => {
   let service: AuthSessionService;
   let httpMock: HttpTestingController;
   let router: { navigateByUrl: jasmine.Spy };
   let authProvider: jasmine.SpyObj<AuthProviderService>;
+  let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
+  let walletsService: jasmine.SpyObj<WalletsService>;
 
   beforeEach(() => {
     router = { navigateByUrl: jasmine.createSpy('navigateByUrl') };
     authProvider = jasmine.createSpyObj<AuthProviderService>(
       'AuthProviderService',
-      ['login', 'getAccessToken'],
+      ['login', 'logout', 'getAccessToken'],
       {
         snapshot: {
           status: 'ready',
@@ -38,12 +42,22 @@ describe('AuthSessionService', () => {
       wallets: [],
     });
     authProvider.getAccessToken.and.resolveTo('provider-token');
+    authProvider.logout.and.resolveTo();
+    walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
+      'WalletGatewayBridgeService',
+      ['disconnectWallet']
+    );
+    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
+      'setAccount',
+    ]);
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
         { provide: Router, useValue: router },
         { provide: AuthProviderService, useValue: authProvider },
+        { provide: WalletGatewayBridgeService, useValue: walletGatewayBridge },
+        { provide: WalletsService, useValue: walletsService },
       ],
     });
 
@@ -77,6 +91,21 @@ describe('AuthSessionService', () => {
       wallets: [],
     });
     expect(service.session?.user.id).toBe('account-1');
+  }));
+
+  it('logs out through the provider and clears host wallet state', fakeAsync(() => {
+    service.login('email');
+    flushMicrotasks();
+    expect(service.session?.user.id).toBe('account-1');
+
+    service.logout();
+    flushMicrotasks();
+
+    expect(authProvider.logout).toHaveBeenCalledTimes(1);
+    expect(walletGatewayBridge.disconnectWallet).toHaveBeenCalledTimes(1);
+    expect(walletsService.setAccount).toHaveBeenCalledOnceWith(undefined);
+    expect(service.session).toBeNull();
+    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/register');
   }));
 
   it('refreshes session and wallets using the provider access token', fakeAsync(() => {

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -4,6 +4,8 @@ import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
 import { AuthProviderService } from './auth-provider.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import {
   AuthSession,
   BackendBalance,
@@ -43,7 +45,9 @@ export class AuthSessionService {
   constructor(
     private readonly httpClient: HttpClient,
     private readonly router: Router,
-    private readonly authProvider: AuthProviderService
+    private readonly authProvider: AuthProviderService,
+    private readonly walletGatewayBridge: WalletGatewayBridgeService,
+    private readonly walletsService: WalletsService
   ) {}
 
   get session(): AuthSession | null {
@@ -97,6 +101,19 @@ export class AuthSessionService {
       this.accessToken = token;
       this.sessionSubject.next(session);
       return session;
+    } finally {
+      this.loadingSubject.next(false);
+    }
+  }
+
+  async logout(): Promise<void> {
+    this.loadingSubject.next(true);
+    try {
+      await this.authProvider.logout().catch(() => undefined);
+      this.walletGatewayBridge.disconnectWallet();
+      this.walletsService.setAccount(undefined);
+      this.clear();
+      await this.router.navigateByUrl('/register');
     } finally {
       this.loadingSubject.next(false);
     }

--- a/src/app/core/auth/auth.guard.spec.ts
+++ b/src/app/core/auth/auth.guard.spec.ts
@@ -19,8 +19,8 @@ describe('AuthGuard', () => {
       'AuthProviderService',
       ['whenSettled']
     );
-    router = jasmine.createSpyObj<Router>('Router', ['parseUrl']);
-    router.parseUrl.and.returnValue({} as UrlTree);
+    router = jasmine.createSpyObj<Router>('Router', ['createUrlTree']);
+    router.createUrlTree.and.returnValue({} as UrlTree);
     guard = new AuthGuard(authSession, authProvider, router);
   });
 
@@ -45,7 +45,12 @@ describe('AuthGuard', () => {
       wallets: [],
     });
 
-    const activation = guard.canActivate();
+    const activation = guard.canActivate(
+      {} as never,
+      {
+        url: '/profile',
+      } as never
+    );
     expect(authSession.refresh).not.toHaveBeenCalled();
     settleProvider?.('ready');
 
@@ -60,9 +65,25 @@ describe('AuthGuard', () => {
       embeddedWalletEnabled: false,
     });
 
-    await guard.canActivate();
+    await guard.canActivate({} as never, { url: '/farm' } as never);
 
     expect(authSession.refresh).not.toHaveBeenCalled();
-    expect(router.parseUrl).toHaveBeenCalledOnceWith('/login');
+    expect(router.createUrlTree).toHaveBeenCalledOnceWith(['/register'], {
+      queryParams: { returnUrl: '/farm' },
+    });
+  });
+
+  it('uses root as the return URL when the requested URL is unsafe', async () => {
+    authProvider.whenSettled.and.resolveTo({
+      status: 'failed',
+      loginMethods: [],
+      embeddedWalletEnabled: false,
+    });
+
+    await guard.canActivate({} as never, { url: '//example.test' } as never);
+
+    expect(router.createUrlTree).toHaveBeenCalledOnceWith(['/register'], {
+      queryParams: { returnUrl: '/' },
+    });
   });
 });

--- a/src/app/core/auth/auth.guard.ts
+++ b/src/app/core/auth/auth.guard.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router, UrlTree } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
 import { AuthSessionService } from './auth-session.service';
 import { AuthProviderService } from './auth-provider.service';
 
@@ -11,7 +17,10 @@ export class AuthGuard implements CanActivate {
     private readonly router: Router
   ) {}
 
-  async canActivate(): Promise<boolean | UrlTree> {
+  async canActivate(
+    _route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean | UrlTree> {
     if (this.authSession.session) {
       return true;
     }
@@ -19,6 +28,14 @@ export class AuthGuard implements CanActivate {
     const provider = await this.authProvider.whenSettled();
     const session =
       provider.status === 'ready' ? await this.authSession.refresh() : null;
-    return session ? true : this.router.parseUrl('/login');
+    return session
+      ? true
+      : this.router.createUrlTree(['/register'], {
+          queryParams: { returnUrl: this.safeReturnUrl(state.url) },
+        });
+  }
+
+  private safeReturnUrl(url: string): string {
+    return url.startsWith('/') && !url.startsWith('//') ? url : '/';
   }
 }

--- a/src/app/mfe-contracts/README.md
+++ b/src/app/mfe-contracts/README.md
@@ -22,6 +22,17 @@ The canonical, open runtime contract is
 the structural consumer copy in `auth-provider.types.ts` and validates contract
 version `2.0.0` before mounting `mfe-wallets/auth-provider`.
 
+The wallet remote exposes atomized entrypoints:
+
+- `./mount` for the generic wallet UI/runtime.
+- `./auth-provider` for the thin auth-provider bootstrap consumed by Angular.
+- `./providers/privy` for the Privy implementation atom owned and loaded by
+  `cs_mfe-wallets`.
+
+Angular should continue to load only `./mount` and `./auth-provider`. It must
+not load `./providers/privy` directly unless provider ownership is intentionally
+moved into the host by a future contract change.
+
 The NestJS `GET /api/v1/public/auth-config` response is the single source of
 truth for enabled login methods and public provider configuration. `mfe-wallets`
 loads that configuration, owns browser provider lifecycle, registers normalized

--- a/src/app/mfe-contracts/auth-provider.types.ts
+++ b/src/app/mfe-contracts/auth-provider.types.ts
@@ -54,6 +54,7 @@ export type AuthProviderMountApi = {
   subscribe: (listener: AuthProviderListener) => () => void;
   getSnapshot: () => AuthProviderSnapshot;
   login: (method: AuthProviderLoginMethod) => Promise<AuthProviderSession>;
+  logout: () => Promise<void>;
   getAccessToken: () => Promise<string | null>;
 };
 

--- a/src/app/mfe-contracts/index.ts
+++ b/src/app/mfe-contracts/index.ts
@@ -1,5 +1,6 @@
 export * from './api-envelope';
 export * from './auth-provider.types';
+export * from './wallet-remote-entrypoints';
 export * from './events';
 export * from './gateway-events';
 export * from './intent-prepare.contract';

--- a/src/app/mfe-contracts/wallet-mfe.types.ts
+++ b/src/app/mfe-contracts/wallet-mfe.types.ts
@@ -23,6 +23,13 @@ export type WalletConnectionSnapshot = {
   errorMessage?: string;
 };
 
+export type WalletOnboardingResult = {
+  account: string;
+  chainId: number | null;
+  walletType: 'embedded' | 'external';
+  source: string;
+};
+
 export type WalletsMfeEvent =
   | {
       type: 'connection.state.changed';
@@ -39,6 +46,7 @@ export type WalletsMfeEvent =
 
 export type WalletsMfeContext = {
   contractVersion?: '2.0.0';
+  apiBaseUrl?: string;
   sessionId?: string;
   locale?: string;
   theme?: 'light' | 'dark';
@@ -71,6 +79,8 @@ export type WalletsMfeMountApi = {
   subscribe: (listener: (event: WalletsMfeEvent) => void) => () => void;
   getSnapshot: () => WalletConnectionSnapshot;
   sendGatewayEvent: (event: WalletGatewayEvent) => void;
+  createEmbeddedWallet?: () => Promise<WalletOnboardingResult>;
+  disconnectWallet?: () => void;
 };
 
 export type WalletsMfeModule = {

--- a/src/app/mfe-contracts/wallet-remote-entrypoints.ts
+++ b/src/app/mfe-contracts/wallet-remote-entrypoints.ts
@@ -1,0 +1,10 @@
+export const WALLET_REMOTE_NAME = 'mfe-wallets';
+
+export const WALLET_REMOTE_EXPOSED_MODULES = {
+  mount: './mount',
+  authProvider: './auth-provider',
+  privyProvider: './providers/privy',
+} as const;
+
+export type WalletRemoteExposedModule =
+  (typeof WALLET_REMOTE_EXPOSED_MODULES)[keyof typeof WALLET_REMOTE_EXPOSED_MODULES];

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -6,9 +6,22 @@
         {{ activeSession.user.email || activeSession.user.providerUserId }}
       </h1>
     </div>
-    <button type="button" mat-stroked-button (click)="requestDeletion()">
-      Request deletion
-    </button>
+    <div class="profile-shell__header-actions">
+      <button
+        type="button"
+        mat-stroked-button
+        [disabled]="authSession.loading$ | async"
+        (click)="logout()">
+        Logout
+      </button>
+      <button
+        type="button"
+        mat-stroked-button
+        [disabled]="authSession.loading$ | async"
+        (click)="requestDeletion()">
+        Request deletion
+      </button>
+    </div>
   </div>
 
   <div class="profile-shell__grid">

--- a/src/app/pages/auth/profile/profile.component.scss
+++ b/src/app/pages/auth/profile/profile.component.scss
@@ -16,12 +16,19 @@
     gap: 1rem;
 
     h1 {
-      overflow-wrap: anywhere;
       margin: 0.25rem 0 0;
       font-size: 1.35rem;
       font-weight: 600;
       line-height: 1.25;
+      overflow-wrap: anywhere;
     }
+  }
+
+  &__header-actions {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.75rem;
   }
 
   &__eyebrow {
@@ -32,8 +39,8 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   &__panel {
@@ -85,19 +92,19 @@
   }
 
   dd {
-    overflow-wrap: anywhere;
     margin: 0;
     color: var(--gray-30);
     font-size: 0.92rem;
     line-height: 1.3;
+    overflow-wrap: anywhere;
   }
 
   &__wallets {
     display: grid;
-    margin: 0;
     padding: 0;
-    list-style: none;
+    margin: 0;
     gap: 0.65rem;
+    list-style: none;
 
     li {
       display: flex;
@@ -124,19 +131,19 @@
 
   &__balances {
     display: grid;
-    margin: 0;
     padding: 0;
-    list-style: none;
+    margin: 0;
     gap: 0.65rem;
+    list-style: none;
 
     li {
       display: grid;
       min-width: 0;
       align-items: center;
-      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-      gap: 1rem;
       padding: 0.7rem 0;
       border-top: 1px solid rgb(255 255 255 / 10%);
+      gap: 1rem;
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
 
       &:first-child {
         border-top: 0;
@@ -188,8 +195,8 @@
 @media (width <= 720px) {
   .profile-shell {
     &__header {
-      align-items: stretch;
       flex-direction: column;
+      align-items: stretch;
     }
 
     &__grid {
@@ -197,8 +204,8 @@
     }
 
     &__wallets li {
-      align-items: flex-start;
       flex-direction: column;
+      align-items: flex-start;
       gap: 0.15rem;
     }
 
@@ -207,8 +214,8 @@
     }
 
     &__balances li {
-      grid-template-columns: 1fr;
       gap: 0.35rem;
+      grid-template-columns: 1fr;
     }
 
     &__balance-value {

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -141,6 +141,18 @@ export class ProfileComponent implements OnInit, OnDestroy {
     }
   }
 
+  public async logout(): Promise<void> {
+    this.error = '';
+    this.walletMessage = '';
+    this.balanceMessage = '';
+    this.deletionMessage = '';
+    try {
+      await this.authSession.logout();
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Logout failed';
+    }
+  }
+
   private rawToDecimal(rawBalance: string, decimals: number): string {
     if (!/^\d+$/.test(rawBalance) || decimals <= 0) {
       return rawBalance;

--- a/src/app/pages/auth/register/register.component.html
+++ b/src/app/pages/auth/register/register.component.html
@@ -24,88 +24,128 @@
         <span>CraftScript</span>
       </div>
 
-      <h2>Welcome to CraftScript</h2>
+      <h2>
+        {{ step === 'account' ? 'Welcome to CraftScript' : 'Set up wallet' }}
+      </h2>
 
-      <form
-        class="register-shell__form"
-        (ngSubmit)="registerWithEmail()"
-        novalidate>
-        <label for="register-email">Email</label>
-        <input
-          id="register-email"
-          name="email"
-          type="email"
-          placeholder="name@example.com"
-          [(ngModel)]="email" />
+      <ng-container *ngIf="authSession.providerSnapshot$ | async as provider">
+        <p class="register-shell__status" *ngIf="provider.status === 'loading'">
+          Account provider is still starting.
+        </p>
+        <p
+          class="register-shell__status"
+          *ngIf="provider.status === 'disabled'">
+          Account registration is not enabled for this environment.
+        </p>
+        <p class="register-shell__status" *ngIf="provider.status === 'failed'">
+          {{
+            provider.error || 'Account registration is temporarily unavailable.'
+          }}
+        </p>
 
-        <label class="register-shell__policy">
-          <input type="checkbox" name="policy" [(ngModel)]="agreedToPolicy" />
-          <span>
-            By creating an account, I agree to CraftScript's
-            <a href="/policy">Terms</a>.
-          </span>
-        </label>
+        <ng-container *ngIf="provider.status === 'ready'">
+          <form
+            *ngIf="step === 'account'"
+            class="register-shell__form"
+            (ngSubmit)="registerWithEmail()"
+            novalidate>
+            <label for="register-email">Email</label>
+            <input
+              id="register-email"
+              name="email"
+              type="email"
+              placeholder="name@example.com"
+              [(ngModel)]="email" />
 
-        <button type="submit" [disabled]="loading">Register</button>
-      </form>
+            <label class="register-shell__policy">
+              <input
+                type="checkbox"
+                name="policy"
+                [(ngModel)]="agreedToPolicy" />
+              <span>
+                By creating an account, I agree to CraftScript's
+                <a href="/policy">Terms</a>.
+              </span>
+            </label>
 
-      <div class="register-shell__divider">
-        <span>or</span>
-      </div>
+            <button type="submit" [disabled]="loading">Register</button>
+          </form>
 
-      <div class="register-shell__socials">
-        <button
-          class="register-shell__social register-shell__social--google"
-          type="button"
-          [disabled]="loading"
-          (click)="continueWith('google')">
-          <span class="register-shell__social-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false">
-              <path
-                fill="#4285F4"
-                d="M23.49 12.27c0-.79-.07-1.54-.2-2.27H12v4.31h6.44a5.5 5.5 0 0 1-2.39 3.61v3h3.87c2.26-2.08 3.57-5.16 3.57-8.65Z" />
-              <path
-                fill="#34A853"
-                d="M12 24c3.24 0 5.96-1.07 7.95-2.91l-3.87-3c-1.07.72-2.43 1.15-4.08 1.15-3.13 0-5.79-2.11-6.74-4.95H1.26v3.09A12 12 0 0 0 12 24Z" />
-              <path
-                fill="#FBBC05"
-                d="M5.26 14.29A7.2 7.2 0 0 1 4.88 12c0-.8.14-1.58.38-2.29V6.62H1.26A12 12 0 0 0 0 12c0 1.94.46 3.77 1.26 5.38l4-3.09Z" />
-              <path
-                fill="#EA4335"
-                d="M12 4.77c1.76 0 3.33.61 4.57 1.8l3.43-3.43C17.95 1.11 15.24 0 12 0A12 12 0 0 0 1.26 6.62l4 3.09c.95-2.84 3.61-4.94 6.74-4.94Z" />
-            </svg>
-          </span>
-          Continue with Google
-        </button>
-        <button
-          class="register-shell__social register-shell__social--apple"
-          type="button"
-          [disabled]="loading"
-          (click)="continueWith('apple')">
-          <span class="register-shell__social-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false">
-              <path
-                fill="currentColor"
-                d="M16.37 12.72c.03 3.21 2.82 4.28 2.85 4.29-.02.08-.44 1.5-1.44 2.97-.86 1.27-1.76 2.53-3.16 2.56-1.37.03-1.81-.81-3.38-.81-1.57 0-2.06.78-3.36.84-1.35.05-2.38-1.36-3.25-2.62-1.78-2.57-3.13-7.26-1.31-10.42.91-1.57 2.54-2.57 4.31-2.6 1.34-.02 2.61.91 3.38.91.77 0 2.22-1.12 3.74-.95.64.03 2.43.26 3.58 1.94-.09.05-2.14 1.25-2.12 3.89Zm-2.65-6.62c.72-.87 1.21-2.08 1.07-3.29-1.04.04-2.29.69-3.03 1.55-.67.77-1.26 1.99-1.1 3.17 1.16.09 2.34-.59 3.06-1.43Z" />
-            </svg>
-          </span>
-          Continue with Apple
-        </button>
-        <button
-          class="register-shell__social register-shell__social--telegram"
-          type="button"
-          [disabled]="loading"
-          (click)="continueWith('telegram')">
-          <span class="register-shell__social-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false">
-              <path
-                fill="currentColor"
-                d="M9.04 15.5 8.66 20.9c.54 0 .77-.23 1.06-.5l2.55-2.43 5.28 3.87c.97.54 1.65.26 1.91-.9l3.46-16.2h0c.31-1.45-.52-2.02-1.47-1.66L1.14 10.92c-1.38.54-1.36 1.31-.24 1.65l5.2 1.62L18.2 6.56c.57-.35 1.08-.16.66.2" />
-            </svg>
-          </span>
-          Continue with Telegram
-        </button>
-      </div>
+          <div class="register-shell__divider" *ngIf="step === 'account'">
+            <span>or</span>
+          </div>
+
+          <div class="register-shell__socials" *ngIf="step === 'account'">
+            <button
+              class="register-shell__social register-shell__social--google"
+              type="button"
+              [disabled]="loading"
+              (click)="continueWith('google')">
+              <span class="register-shell__social-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path
+                    fill="#4285F4"
+                    d="M23.49 12.27c0-.79-.07-1.54-.2-2.27H12v4.31h6.44a5.5 5.5 0 0 1-2.39 3.61v3h3.87c2.26-2.08 3.57-5.16 3.57-8.65Z" />
+                  <path
+                    fill="#34A853"
+                    d="M12 24c3.24 0 5.96-1.07 7.95-2.91l-3.87-3c-1.07.72-2.43 1.15-4.08 1.15-3.13 0-5.79-2.11-6.74-4.95H1.26v3.09A12 12 0 0 0 12 24Z" />
+                  <path
+                    fill="#FBBC05"
+                    d="M5.26 14.29A7.2 7.2 0 0 1 4.88 12c0-.8.14-1.58.38-2.29V6.62H1.26A12 12 0 0 0 0 12c0 1.94.46 3.77 1.26 5.38l4-3.09Z" />
+                  <path
+                    fill="#EA4335"
+                    d="M12 4.77c1.76 0 3.33.61 4.57 1.8l3.43-3.43C17.95 1.11 15.24 0 12 0A12 12 0 0 0 1.26 6.62l4 3.09c.95-2.84 3.61-4.94 6.74-4.94Z" />
+                </svg>
+              </span>
+              Continue with Google
+            </button>
+            <button
+              class="register-shell__social register-shell__social--apple"
+              type="button"
+              [disabled]="loading"
+              (click)="continueWith('apple')">
+              <span class="register-shell__social-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path
+                    fill="currentColor"
+                    d="M16.37 12.72c.03 3.21 2.82 4.28 2.85 4.29-.02.08-.44 1.5-1.44 2.97-.86 1.27-1.76 2.53-3.16 2.56-1.37.03-1.81-.81-3.38-.81-1.57 0-2.06.78-3.36.84-1.35.05-2.38-1.36-3.25-2.62-1.78-2.57-3.13-7.26-1.31-10.42.91-1.57 2.54-2.57 4.31-2.6 1.34-.02 2.61.91 3.38.91.77 0 2.22-1.12 3.74-.95.64.03 2.43.26 3.58 1.94-.09.05-2.14 1.25-2.12 3.89Zm-2.65-6.62c.72-.87 1.21-2.08 1.07-3.29-1.04.04-2.29.69-3.03 1.55-.67.77-1.26 1.99-1.1 3.17 1.16.09 2.34-.59 3.06-1.43Z" />
+                </svg>
+              </span>
+              Continue with Apple
+            </button>
+          </div>
+
+          <div class="register-shell__wallet-step" *ngIf="step === 'wallet'">
+            <p>
+              Link a wallet before entering the dApp. You can connect an
+              existing wallet or create an embedded wallet secured by your
+              account.
+            </p>
+
+            <button
+              class="register-shell__wallet-action"
+              type="button"
+              [disabled]="walletLoading"
+              (click)="connectExistingWallet()">
+              Connect existing wallet
+            </button>
+            <button
+              class="register-shell__wallet-action register-shell__wallet-action--primary"
+              type="button"
+              [disabled]="walletLoading"
+              (click)="generateWallet()">
+              Generate wallet
+            </button>
+            <button
+              class="register-shell__wallet-refresh"
+              type="button"
+              [disabled]="walletLoading"
+              (click)="finishAfterWalletLinked()">
+              Continue after wallet is connected
+            </button>
+          </div>
+        </ng-container>
+      </ng-container>
 
       <p class="register-shell__error" *ngIf="error">{{ error }}</p>
       <p class="register-shell__info-note" *ngIf="info">{{ info }}</p>
@@ -113,6 +153,12 @@
       <p class="register-shell__login-link">
         Already have an account? <a routerLink="/login">Log in</a>
       </p>
+
+      <app-side-modal
+        [isOpen]="isOpenWalletConnectMenu"
+        (closeRequested)="closeWalletConnectMenu()">
+        <app-wallets />
+      </app-side-modal>
     </section>
   </div>
 </section>

--- a/src/app/pages/auth/register/register.component.spec.ts
+++ b/src/app/pages/auth/register/register.component.spec.ts
@@ -1,0 +1,170 @@
+import { convertToParamMap, ParamMap, Router } from '@angular/router';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
+import { of } from 'rxjs';
+import { RegisterComponent } from './register.component';
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let authSession: jasmine.SpyObj<AuthSessionService>;
+  let router: jasmine.SpyObj<Router>;
+  let walletsService: jasmine.SpyObj<WalletsService>;
+  let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
+  let queryParamMap: ParamMap;
+
+  beforeEach(() => {
+    authSession = jasmine.createSpyObj<AuthSessionService>(
+      'AuthSessionService',
+      ['login', 'reloadWallets'],
+      {
+        providerSnapshot$: of({
+          status: 'ready' as const,
+          loginMethods: ['email' as const],
+          embeddedWalletEnabled: true,
+        }),
+      }
+    );
+    router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
+    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
+      'requestOpen',
+    ]);
+    walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
+      'WalletGatewayBridgeService',
+      ['createEmbeddedWallet']
+    );
+    queryParamMap = convertToParamMap({});
+    router.navigateByUrl.and.resolveTo(true);
+
+    component = new RegisterComponent(
+      authSession,
+      router,
+      { snapshot: { queryParamMap } } as never,
+      walletsService,
+      walletGatewayBridge
+    );
+  });
+
+  it('requires a valid email and accepted policy before email registration', async () => {
+    await component.registerWithEmail();
+
+    expect(component.error).toBe('Email is required.');
+    expect(authSession.login).not.toHaveBeenCalled();
+
+    component.email = 'not-an-email';
+    await component.registerWithEmail();
+
+    expect(component.error).toBe('Enter a valid email address.');
+    expect(authSession.login).not.toHaveBeenCalled();
+
+    component.email = 'user@example.com';
+    await component.registerWithEmail();
+
+    expect(component.error).toBe('Please accept the policy to continue.');
+    expect(authSession.login).not.toHaveBeenCalled();
+  });
+
+  it('navigates to a safe return URL when login already has wallets', async () => {
+    queryParamMap = convertToParamMap({ returnUrl: '/farm' });
+    component = createComponent();
+    component.agreedToPolicy = true;
+    authSession.login.and.resolveTo({
+      user: {
+        id: 'account-1',
+        providerUserId: 'provider-user-1',
+        sessionId: 'session-1',
+      },
+      wallets: [
+        {
+          id: 'wallet-1',
+          providerWalletId: 'wallet-1',
+          address: '0x1111111111111111111111111111111111111111',
+          chainType: 'ethereum',
+          walletType: 'embedded',
+          isPrimary: true,
+        },
+      ],
+    });
+
+    await component.continueWith('google');
+
+    expect(authSession.login).toHaveBeenCalledOnceWith('google');
+    expect(authSession.reloadWallets).not.toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/farm');
+  });
+
+  it('moves to the wallet step when login and refresh return no wallets', async () => {
+    component.agreedToPolicy = true;
+    authSession.login.and.resolveTo({
+      user: {
+        id: 'account-1',
+        providerUserId: 'provider-user-1',
+        sessionId: 'session-1',
+      },
+      wallets: [],
+    });
+    authSession.reloadWallets.and.resolveTo([]);
+
+    await component.continueWith('apple');
+
+    expect(authSession.reloadWallets).toHaveBeenCalledTimes(1);
+    expect(component.step).toBe('wallet');
+    expect(component.info).toBe(
+      'Choose how you want to secure your wallet access.'
+    );
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('opens the wallet connector from the wallet step', () => {
+    component.connectExistingWallet();
+
+    expect(component.isOpenWalletConnectMenu).toBeTrue();
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates an embedded wallet and navigates after backend wallet refresh', async () => {
+    queryParamMap = convertToParamMap({ returnUrl: '//evil.example' });
+    component = createComponent();
+    walletGatewayBridge.createEmbeddedWallet.and.resolveTo({
+      account: '0x1111111111111111111111111111111111111111',
+      chainId: 1,
+      walletType: 'embedded',
+      source: 'provider',
+    });
+    authSession.reloadWallets.and.resolveTo([
+      {
+        id: 'wallet-1',
+        providerWalletId: 'wallet-1',
+        address: '0x1111111111111111111111111111111111111111',
+        chainType: 'ethereum',
+        walletType: 'embedded',
+        isPrimary: true,
+      },
+    ]);
+
+    await component.generateWallet();
+
+    expect(walletGatewayBridge.createEmbeddedWallet).toHaveBeenCalledTimes(1);
+    expect(authSession.reloadWallets).toHaveBeenCalledTimes(1);
+    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/');
+  });
+
+  it('requires a linked wallet before finishing wallet onboarding', async () => {
+    authSession.reloadWallets.and.resolveTo([]);
+
+    await component.finishAfterWalletLinked();
+
+    expect(component.error).toBe('Connect or generate a wallet to continue.');
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  function createComponent(): RegisterComponent {
+    return new RegisterComponent(
+      authSession,
+      router,
+      { snapshot: { queryParamMap } } as never,
+      walletsService,
+      walletGatewayBridge
+    );
+  }
+});

--- a/src/app/pages/auth/register/register.component.ts
+++ b/src/app/pages/auth/register/register.component.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AuthSessionService } from '@core/auth/auth-session.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import type { LoginMethod } from '@core/auth/auth-session.types';
 
-type SocialRegistrationMethod = 'google' | 'apple' | 'telegram';
+type RegistrationMethod = 'email' | 'google' | 'apple';
+type RegisterStep = 'account' | 'wallet';
 
 @Component({
   selector: 'app-register',
@@ -15,12 +18,18 @@ export class RegisterComponent {
   public email = '';
   public agreedToPolicy = false;
   public loading = false;
+  public walletLoading = false;
+  public isOpenWalletConnectMenu = false;
+  public step: RegisterStep = 'account';
   public error = '';
   public info = '';
 
   constructor(
-    private readonly authSession: AuthSessionService,
-    private readonly router: Router
+    public readonly authSession: AuthSessionService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute,
+    private readonly walletsService: WalletsService,
+    private readonly walletGatewayBridge: WalletGatewayBridgeService
   ) {}
 
   public async registerWithEmail(): Promise<void> {
@@ -42,11 +51,10 @@ export class RegisterComponent {
       return;
     }
 
-    this.info =
-      'Email registration will be enabled soon. Use Google or Apple for now.';
+    await this.continueWith('email');
   }
 
-  public async continueWith(method: SocialRegistrationMethod): Promise<void> {
+  public async continueWith(method: RegistrationMethod): Promise<void> {
     this.error = '';
     this.info = '';
 
@@ -55,15 +63,16 @@ export class RegisterComponent {
       return;
     }
 
-    if (method === 'telegram') {
-      this.info = 'Telegram registration is coming soon.';
-      return;
-    }
-
     this.loading = true;
     try {
-      await this.authSession.login(method as LoginMethod);
-      await this.router.navigateByUrl('/profile');
+      const session = await this.authSession.login(method as LoginMethod);
+      if (await this.hasLinkedWallets(session.wallets.length)) {
+        await this.navigateToReturnUrl();
+        return;
+      }
+
+      this.step = 'wallet';
+      this.info = 'Choose how you want to secure your wallet access.';
     } catch (error) {
       this.error =
         error instanceof Error ? error.message : 'Registration failed';
@@ -72,7 +81,80 @@ export class RegisterComponent {
     }
   }
 
+  public connectExistingWallet(): void {
+    this.error = '';
+    this.info = '';
+    this.isOpenWalletConnectMenu = true;
+    this.walletsService.requestOpen();
+  }
+
+  public closeWalletConnectMenu(): void {
+    this.isOpenWalletConnectMenu = false;
+  }
+
+  public async generateWallet(): Promise<void> {
+    this.error = '';
+    this.info = '';
+    this.walletLoading = true;
+
+    try {
+      await this.walletGatewayBridge.createEmbeddedWallet();
+      const wallets = await this.authSession.reloadWallets();
+      if (wallets.length === 0) {
+        throw new Error(
+          'Wallet was created but profile refresh returned no wallets.'
+        );
+      }
+      await this.navigateToReturnUrl();
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Wallet setup failed';
+    } finally {
+      this.walletLoading = false;
+    }
+  }
+
+  public async finishAfterWalletLinked(): Promise<void> {
+    this.error = '';
+    this.info = '';
+    this.walletLoading = true;
+
+    try {
+      const wallets = await this.authSession.reloadWallets();
+      if (wallets.length === 0) {
+        this.error = 'Connect or generate a wallet to continue.';
+        return;
+      }
+      await this.navigateToReturnUrl();
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Wallet refresh failed';
+    } finally {
+      this.walletLoading = false;
+    }
+  }
+
   private isEmail(value: string): boolean {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+  }
+
+  private async hasLinkedWallets(initialCount: number): Promise<boolean> {
+    if (initialCount > 0) {
+      return true;
+    }
+
+    const wallets = await this.authSession.reloadWallets();
+    return wallets.length > 0;
+  }
+
+  private navigateToReturnUrl(): Promise<boolean> {
+    return this.router.navigateByUrl(this.returnUrl());
+  }
+
+  private returnUrl(): string {
+    const value = this.route.snapshot.queryParamMap.get('returnUrl');
+    return value && value.startsWith('/') && !value.startsWith('//')
+      ? value
+      : '/';
   }
 }

--- a/src/app/pages/farm/farm-routing.module.ts
+++ b/src/app/pages/farm/farm-routing.module.ts
@@ -1,11 +1,13 @@
 import { RouterModule, Routes } from '@angular/router';
 import { FarmComponent } from './farm.component';
 import { NgModule } from '@angular/core';
+import { AuthGuard } from '@core/auth/auth.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: FarmComponent,
+    canActivate: [AuthGuard],
   },
 ];
 

--- a/src/app/pages/proposal/proposal-routing.module.ts
+++ b/src/app/pages/proposal/proposal-routing.module.ts
@@ -1,11 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ProposalComponent } from '../proposal/proposal.component';
+import { AuthGuard } from '@core/auth/auth.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: ProposalComponent,
+    canActivate: [AuthGuard],
   },
 ];
 

--- a/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.spec.ts
+++ b/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.spec.ts
@@ -1,0 +1,104 @@
+import { AppLoggerService } from '@core/logging/app-logger.service';
+import {
+  WalletConnectionSnapshot,
+  WalletsMfeMountApi,
+} from '@mfe-contracts/wallet-mfe.types';
+import { WalletGatewayBridgeService } from './wallet-gateway.bridge.service';
+
+describe('WalletGatewayBridgeService', () => {
+  let service: WalletGatewayBridgeService;
+  let mountApi: WalletsMfeMountApi;
+
+  const account = '0x1111111111111111111111111111111111111111';
+  const connectedSnapshot: WalletConnectionSnapshot = {
+    status: 'connected',
+    account,
+    chainId: 1,
+    isVerified: true,
+    safetyStatus: 'safe',
+    isBypassed: false,
+    executionState: 'operating.idle',
+  };
+
+  beforeEach(() => {
+    service = new WalletGatewayBridgeService(
+      jasmine.createSpyObj<AppLoggerService>('AppLoggerService', ['log'])
+    );
+    mountApi = {
+      unmount: jasmine.createSpy('unmount'),
+      subscribe: jasmine
+        .createSpy('subscribe')
+        .and.returnValue(jasmine.createSpy('unsubscribe')),
+      getSnapshot: jasmine
+        .createSpy('getSnapshot')
+        .and.returnValue(connectedSnapshot),
+      sendGatewayEvent: jasmine.createSpy('sendGatewayEvent'),
+    };
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem('mfe-wallets.session.v1');
+  });
+
+  it('delegates embedded wallet creation to the mounted wallet MFE', async () => {
+    const createEmbeddedWallet = jasmine
+      .createSpy('createEmbeddedWallet')
+      .and.resolveTo({
+        account,
+        chainId: connectedSnapshot.chainId,
+        walletType: 'embedded',
+        source: 'provider',
+      });
+    mountApi.createEmbeddedWallet = createEmbeddedWallet;
+    service.registerMountApi(mountApi);
+
+    await expectAsync(service.createEmbeddedWallet()).toBeResolvedTo({
+      account,
+      chainId: connectedSnapshot.chainId,
+      walletType: 'embedded',
+      source: 'provider',
+    });
+    expect(createEmbeddedWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails with a retryable gateway error when embedded wallet creation is unavailable', async () => {
+    service.registerMountApi(mountApi);
+
+    await expectAsync(service.createEmbeddedWallet()).toBeRejectedWith(
+      jasmine.objectContaining({
+        code: 'GATEWAY_UNAVAILABLE',
+        retryable: true,
+      })
+    );
+  });
+
+  it('delegates wallet disconnect and publishes a disconnected snapshot', () => {
+    mountApi.disconnectWallet = jasmine.createSpy('disconnectWallet');
+    service.registerMountApi(mountApi);
+    let latestSnapshot: WalletConnectionSnapshot | undefined;
+    const subscription = service.snapshot$.subscribe(snapshot => {
+      latestSnapshot = snapshot;
+    });
+
+    service.disconnectWallet();
+
+    expect(mountApi.disconnectWallet).toHaveBeenCalledTimes(1);
+    expect(latestSnapshot).toEqual(
+      jasmine.objectContaining({
+        status: 'disconnected',
+        account: null,
+        chainId: null,
+      })
+    );
+    subscription.unsubscribe();
+  });
+
+  it('clears the legacy wallet session fallback when disconnect is unavailable', () => {
+    window.localStorage.setItem('mfe-wallets.session.v1', 'cached');
+    service.registerMountApi(mountApi);
+
+    service.disconnectWallet();
+
+    expect(window.localStorage.getItem('mfe-wallets.session.v1')).toBeNull();
+  });
+});

--- a/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
+++ b/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
@@ -14,11 +14,24 @@ import type {
 } from '@mfe-contracts/wallet-execution.types';
 import type {
   WalletConnectionSnapshot,
+  WalletOnboardingResult,
   WalletsMfeMountApi,
 } from '@mfe-contracts/wallet-mfe.types';
 import { AppLoggerService } from '@core/logging/app-logger.service';
 
 const SIGNATURE_WAIT_MS = 120_000;
+
+const WALLET_SESSION_STORAGE_KEY = 'mfe-wallets.session.v1';
+
+const DISCONNECTED_SNAPSHOT: WalletConnectionSnapshot = {
+  status: 'disconnected',
+  account: null,
+  chainId: null,
+  isVerified: false,
+  safetyStatus: null,
+  isBypassed: false,
+  executionState: 'operating.idle',
+};
 
 @Injectable({
   providedIn: 'root',
@@ -153,6 +166,30 @@ export class WalletGatewayBridgeService {
       message: 'Swap signing aborted',
       retryable: true,
     });
+  }
+
+  disconnectWallet(): void {
+    const disconnect = this.mountApi?.disconnectWallet;
+    if (disconnect) {
+      disconnect();
+    } else {
+      window.localStorage.removeItem(WALLET_SESSION_STORAGE_KEY);
+    }
+
+    this.snapshotSubject.next(DISCONNECTED_SNAPSHOT);
+  }
+
+  async createEmbeddedWallet(): Promise<WalletOnboardingResult> {
+    const createEmbeddedWallet = this.mountApi?.createEmbeddedWallet;
+    if (!createEmbeddedWallet) {
+      throw this.executionFailure(
+        'GATEWAY_UNAVAILABLE',
+        'Embedded wallet creation is not available',
+        true
+      );
+    }
+
+    return createEmbeddedWallet();
   }
 
   private canSendGatewayEvent(): boolean {

--- a/src/app/shared/mfe/wallets/wallets.component.ts
+++ b/src/app/shared/mfe/wallets/wallets.component.ts
@@ -13,6 +13,10 @@ import {
   WalletsMfeModule,
   WalletsMfeMountApi,
 } from '@mfe-contracts/wallet-mfe.types';
+import {
+  WALLET_REMOTE_EXPOSED_MODULES,
+  WALLET_REMOTE_NAME,
+} from '@mfe-contracts/wallet-remote-entrypoints';
 import { WalletAccountChangedPayload } from '@mfe-contracts/payloads';
 import { AppLoggerService } from '@core/logging/app-logger.service';
 import { AuthSessionService } from '@core/auth/auth-session.service';
@@ -31,7 +35,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
   private unmountMfe: (() => void) | undefined;
   private unsubscribeEvents: (() => void) | undefined;
   private isDestroyed = false;
-  private readonly remoteName = 'mfe-wallets';
+  private readonly remoteName = WALLET_REMOTE_NAME;
 
   constructor(
     private walletsService: WalletsService,
@@ -60,7 +64,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
       const mfeModule = (await loadRemoteModule({
         type: 'manifest',
         remoteName: this.remoteName,
-        exposedModule: './mount',
+        exposedModule: WALLET_REMOTE_EXPOSED_MODULES.mount,
       })) as WalletsMfeModule;
       this.logger.log('info', 'Wallets MFE: remote module loaded', {
         component: 'WalletsComponent',
@@ -82,6 +86,7 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
       const mountResult = mfeModule.mount(container, {
         context: {
           contractVersion: '2.0.0',
+          apiBaseUrl: environment.apiUrl,
           environment: this.mfeEnvironment(),
         },
         callbacks: {

--- a/src/styles/exchange-page.scss
+++ b/src/styles/exchange-page.scss
@@ -514,67 +514,6 @@
     box-sizing: border-box;
     flex-direction: column;
     padding: 24px 28px;
-
-    &--advanced {
-      .marketAdvanced {
-        display: flex;
-        min-height: 0;
-        flex: 1 1 auto;
-        flex-direction: column;
-        justify-content: flex-start;
-        margin-top: 0;
-
-        app-live-chart {
-          display: flex;
-          overflow: hidden;
-          min-height: 0;
-          flex: 0 0 auto;
-          flex-direction: column;
-          height: calc(486px - 48px - 44px);
-        }
-      }
-
-      .marketFooter--advanced {
-        flex-shrink: 0;
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-        margin-top: 10px;
-        gap: 16px;
-
-        .note {
-          min-width: 0;
-          flex: 1 1 auto;
-          text-align: left;
-          white-space: nowrap;
-        }
-
-        .advanced {
-          flex-shrink: 0;
-        }
-      }
-
-      ::ng-deep .live-chart {
-        height: 100%;
-        min-height: 0;
-        padding-top: 0;
-      }
-
-      ::ng-deep .live-chart__header {
-        margin-bottom: 0.5rem;
-      }
-
-      ::ng-deep .live-chart__panel {
-        min-height: 0;
-        flex: 1 1 0;
-      }
-
-      ::ng-deep .live-chart__canvas {
-        min-height: 0;
-        flex: 1 1 0;
-        height: 100%;
-      }
-    }
   }
 
   .marketHead {
@@ -644,10 +583,6 @@
     grid-template-rows: minmax(0, 1fr) auto;
   }
 
-  .marketPanel > .marketAdvanced:first-child {
-    margin-top: 0;
-  }
-
   .marketAdvanced {
     overflow: hidden;
     min-height: 0;
@@ -677,69 +612,10 @@
     }
 
     ::ng-deep .live-chart__canvas {
+      height: 100%;
       min-height: 0;
       flex: 1 1 0;
-      height: 100%;
       aspect-ratio: auto;
-    }
-  }
-
-  .marketSummary {
-    min-width: 0;
-    flex: 0 1 auto;
-
-    .market-skeleton {
-      margin-top: 8px;
-    }
-  }
-
-  .marketBelow {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-rows: auto auto auto;
-    align-items: center;
-    column-gap: 24px;
-    row-gap: 0;
-    grid-row: 2;
-
-    .marketSummary,
-    .marketFooter {
-      display: contents;
-    }
-
-    .pair {
-      grid-column: 1;
-      grid-row: 1;
-      align-self: center;
-    }
-
-    .note {
-      grid-column: 2;
-      grid-row: 1;
-      align-self: start;
-      white-space: nowrap;
-    }
-
-    .price {
-      grid-column: 1;
-      grid-row: 2;
-    }
-
-    .marketSummary .market-skeleton {
-      grid-column: 1;
-      grid-row: 2;
-    }
-
-    .change {
-      grid-column: 1;
-      grid-row: 3;
-    }
-
-    .advanced {
-      grid-column: 2;
-      grid-row: 2;
-      align-self: center;
-      justify-self: end;
     }
   }
 
@@ -789,11 +665,11 @@
   }
 
   .price {
+    overflow: hidden;
+    max-width: 100%;
     margin-top: 10px;
     font-size: 26px;
     line-height: 1.1;
-    overflow: hidden;
-    max-width: 100%;
     text-overflow: ellipsis;
     white-space: nowrap;
 
@@ -847,6 +723,15 @@
         height: 100%;
         min-height: 0;
       }
+    }
+  }
+
+  .marketSummary {
+    min-width: 0;
+    flex: 0 1 auto;
+
+    .market-skeleton {
+      margin-top: 8px;
     }
   }
 
@@ -910,6 +795,119 @@
     line-height: 1.2;
     text-transform: uppercase;
     white-space: nowrap;
+  }
+
+  .marketBelow {
+    display: grid;
+    align-items: center;
+    gap: 0 24px;
+    grid-row: 2;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: auto auto auto;
+
+    .marketSummary,
+    .marketFooter {
+      display: contents;
+    }
+
+    .pair {
+      align-self: center;
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .note {
+      align-self: start;
+      grid-column: 2;
+      grid-row: 1;
+      white-space: nowrap;
+    }
+
+    .price {
+      grid-column: 1;
+      grid-row: 2;
+    }
+
+    .marketSummary .market-skeleton {
+      grid-column: 1;
+      grid-row: 2;
+    }
+
+    .change {
+      grid-column: 1;
+      grid-row: 3;
+    }
+
+    .advanced {
+      grid-column: 2;
+      grid-row: 2;
+      place-self: center end;
+    }
+  }
+
+  .marketPanel--advanced {
+    .marketAdvanced {
+      display: flex;
+      min-height: 0;
+      flex: 1 1 auto;
+      flex-direction: column;
+      justify-content: flex-start;
+      margin-top: 0;
+
+      app-live-chart {
+        display: flex;
+        overflow: hidden;
+        height: calc(486px - 48px - 44px);
+        min-height: 0;
+        flex: 0 0 auto;
+        flex-direction: column;
+      }
+    }
+
+    .marketFooter--advanced {
+      flex-direction: row;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: space-between;
+      margin-top: 10px;
+      gap: 16px;
+
+      .note {
+        min-width: 0;
+        flex: 1 1 auto;
+        text-align: left;
+        white-space: nowrap;
+      }
+
+      .advanced {
+        flex-shrink: 0;
+      }
+    }
+
+    ::ng-deep .live-chart {
+      height: 100%;
+      min-height: 0;
+      padding-top: 0;
+    }
+
+    ::ng-deep .live-chart__header {
+      margin-bottom: 0.5rem;
+    }
+
+    ::ng-deep .live-chart__panel {
+      min-height: 0;
+      flex: 1 1 0;
+    }
+
+    ::ng-deep .live-chart__canvas {
+      height: 100%;
+      min-height: 0;
+      flex: 1 1 0;
+    }
+  }
+
+  .marketPanel > .marketAdvanced:first-child {
+    margin-top: 0;
   }
 
   .activity {
@@ -1108,21 +1106,6 @@
       padding: 20px 16px;
     }
 
-    .marketPanel--advanced {
-      .marketAdvanced app-live-chart {
-        height: 22rem;
-      }
-
-      .marketFooter--advanced {
-        flex-direction: column;
-        align-items: flex-start;
-
-        .note {
-          white-space: normal;
-        }
-      }
-    }
-
     .marketBody {
       margin-top: 16px;
       gap: 12px;
@@ -1147,6 +1130,15 @@
       padding: 20px 16px;
     }
 
+    .marketFooter {
+      flex: 0 0 auto;
+      align-items: flex-start;
+    }
+
+    .note {
+      text-align: left;
+    }
+
     .marketBelow {
       display: flex;
       flex-direction: column;
@@ -1167,8 +1159,7 @@
       .marketSummary .market-skeleton {
         grid-column: auto;
         grid-row: auto;
-        align-self: auto;
-        justify-self: auto;
+        place-self: auto auto;
       }
 
       .note {
@@ -1176,13 +1167,19 @@
       }
     }
 
-    .marketFooter {
-      flex: 0 0 auto;
-      align-items: flex-start;
-    }
+    .marketPanel--advanced {
+      .marketAdvanced app-live-chart {
+        height: 22rem;
+      }
 
-    .note {
-      text-align: left;
+      .marketFooter--advanced {
+        flex-direction: column;
+        align-items: flex-start;
+
+        .note {
+          white-space: normal;
+        }
+      }
     }
   }
 }

--- a/src/styles/register-page.scss
+++ b/src/styles/register-page.scss
@@ -2,18 +2,18 @@
   display: grid;
   min-height: 100vh;
   align-content: center;
-  justify-items: center;
   padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 4vw, 3.5rem);
   background:
     radial-gradient(circle at left 20%, rgb(255 108 0 / 10%), transparent 45%),
     var(--main-bg-color);
+  justify-items: center;
 
   &__content {
     display: grid;
     width: 100%;
     max-width: 78rem;
-    margin: 0;
     align-items: center;
+    margin: 0;
     gap: clamp(1.5rem, 6vw, 6rem);
     grid-template-columns: minmax(0, 1fr) minmax(30rem, 36rem);
   }
@@ -35,8 +35,8 @@
   h1 {
     margin: 0;
     font-size: clamp(2rem, 4.2vw, 3.25rem);
-    line-height: 1.12;
     letter-spacing: -0.02em;
+    line-height: 1.12;
   }
 
   &__subtitle {
@@ -51,8 +51,8 @@
     display: grid;
     padding: 0;
     margin: 0;
-    list-style: none;
     gap: 0.65rem;
+    list-style: none;
 
     li {
       color: rgb(255 255 255 / 86%);
@@ -130,8 +130,8 @@
 
       &:focus {
         border-color: var(--primary-text-color);
-        outline: none;
         box-shadow: 0 0 0 3px rgb(254 108 0 / 14%);
+        outline: none;
       }
     }
 
@@ -174,8 +174,8 @@
 
   &__socials {
     display: grid;
-    gap: 0.95rem;
     margin-top: 0.2rem;
+    gap: 0.95rem;
 
     button {
       position: relative;
@@ -222,20 +222,62 @@
     color: #fff;
   }
 
-  &__social--telegram .register-shell__social-icon {
-    width: 1.2rem;
-    height: 1.2rem;
-    color: #2aabee;
+  &__wallet-step {
+    display: grid;
+    gap: 0.85rem;
+
+    p {
+      margin: 0;
+      color: rgb(255 255 255 / 70%);
+      font-size: 0.95rem;
+      line-height: 1.45;
+    }
+  }
+
+  &__wallet-action,
+  &__wallet-refresh {
+    min-height: 3.45rem;
+    border: 1px solid rgb(212 212 211 / 20%);
+    border-radius: 0.5rem;
+    background: rgb(23 29 33 / 90%);
+    color: var(--main-text-color);
+    font-size: 1.02rem;
+    font-weight: 600;
+  }
+
+  &__wallet-action--primary {
+    border-color: transparent;
+    background: var(--primary-text-color);
+  }
+
+  &__wallet-refresh {
+    min-height: auto;
+    border: 0;
+    background: transparent;
+    color: var(--primary-text-color);
+    font-size: 0.95rem;
+  }
+
+  &__login-link {
+    margin: 0.85rem 0 0;
+    color: rgb(255 255 255 / 70%);
+    font-size: 1rem;
+    text-align: center;
+
+    a {
+      color: var(--primary-text-color);
+      text-decoration: none;
+    }
   }
 
   &__policy {
     display: grid;
-    margin: 0.35rem 0 0.6rem;
     align-items: start;
-    grid-template-columns: 18px 1fr;
-    gap: 0.625rem;
+    margin: 0.35rem 0 0.6rem;
     color: rgb(255 255 255 / 62%);
     font-size: 1rem;
+    gap: 0.625rem;
+    grid-template-columns: 18px 1fr;
     line-height: 1.35;
 
     input[type='checkbox'] {
@@ -266,22 +308,17 @@
     font-size: 0.85rem;
   }
 
+  &__status {
+    margin: 0;
+    color: rgb(255 255 255 / 72%);
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
   &__info-note {
     margin: 0;
     color: #9ad1ff;
     font-size: 0.85rem;
-  }
-
-  &__login-link {
-    margin: 0.85rem 0 0;
-    color: rgb(255 255 255 / 70%);
-    font-size: 1rem;
-    text-align: center;
-
-    a {
-      color: var(--primary-text-color);
-      text-decoration: none;
-    }
   }
 }
 
@@ -291,9 +328,9 @@
     padding: 0.75rem 0.75rem 1.25rem;
 
     &__content {
+      max-width: none;
       gap: 1.5rem;
       grid-template-columns: 1fr;
-      max-width: none;
     }
 
     &__info {
@@ -325,9 +362,22 @@
       }
     }
 
+    &__brand {
+      gap: 0.45rem;
+
+      img {
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+
+      span {
+        font-size: 1.35rem;
+      }
+    }
+
     &__panel {
-      order: 1;
       width: 100%;
+      order: 1;
       padding: 0.75rem 0.25rem 0.5rem;
       border: 0;
       border-radius: 0;
@@ -342,19 +392,6 @@
       .register-shell__divider span {
         background: var(--main-bg-color);
         font-size: 0.875rem;
-      }
-    }
-
-    &__brand {
-      gap: 0.45rem;
-
-      img {
-        width: 1.5rem;
-        height: 1.5rem;
-      }
-
-      span {
-        font-size: 1.35rem;
       }
     }
 
@@ -401,9 +438,9 @@
       height: 1rem;
     }
 
-    &__social--telegram .register-shell__social-icon {
-      width: 1.05rem;
-      height: 1.05rem;
+    &__wallet-action {
+      min-height: 2.75rem;
+      font-size: 0.92rem;
     }
 
     &__policy {


### PR DESCRIPTION
* Integrate Privy register onboarding

* feat(auth): add profile logout and improve register onboarding UX

Wire auth-provider logout and wallet disconnect through AuthSessionService, add a Profile Logout button (redirects to /register), show auth-provider status on the register page, and reload wallets after login before wallet setup.

* fix: revert manifest

* test: import wallet auth session test dependencies

* test: cover register wallet onboarding

* fix: keep exchange route public for shell e2e

* refactor(mfe): align wallet remote atoms

---------