### PR TITLE
release: add profile passkey enablement

### DIFF
--- a/ARCHITECTURE_GUIDE.md
+++ b/ARCHITECTURE_GUIDE.md
@@ -64,9 +64,11 @@ Angular begins only at the final boundary. It:
 - mounts `./auth-provider` with the generic backend `apiBaseUrl`;
 - consumes versioned provider-neutral snapshots and normalized sessions;
 - may use generic bearer tokens for backend API access;
+- may call provider-neutral account actions such as `linkPasskey()` and render
+  normalized session fields such as `passkeyEnabled`;
 - must not import the Privy SDK, parse Privy configuration, register wallets,
-  interpret Privy linked accounts, or expose Privy-specific fields in UI/domain
-  models.
+  interpret Privy linked accounts, store passkey credential IDs, or expose
+  Privy-specific fields in UI/domain models.
 
 Any change that would move those responsibilities into Angular is an
 architecture change, not a local implementation shortcut, and requires updates

--- a/src/app/core/auth/auth-provider.service.spec.ts
+++ b/src/app/core/auth/auth-provider.service.spec.ts
@@ -18,7 +18,7 @@ function mountApi(
   onSubscribe?: (listener: AuthProviderListener) => void
 ): AuthProviderMountApi {
   return {
-    contractVersion: '2.1.0',
+    contractVersion: '2.2.0',
     unmount: jasmine.createSpy('unmount'),
     subscribe: listener => {
       onSubscribe?.(listener);
@@ -40,6 +40,15 @@ function mountApi(
         id: 'account-1',
         providerUserId: 'provider-user-1',
         sessionId: 'session-1',
+      },
+      wallets: [],
+    }),
+    linkPasskey: async () => ({
+      user: {
+        id: 'account-1',
+        providerUserId: 'provider-user-1',
+        sessionId: 'session-1',
+        passkeyEnabled: true,
       },
       wallets: [],
     }),

--- a/src/app/core/auth/auth-provider.service.ts
+++ b/src/app/core/auth/auth-provider.service.ts
@@ -82,6 +82,10 @@ export class AuthProviderService implements OnDestroy {
     return this.requireReadyProvider().verifyEmailCode(input);
   }
 
+  linkPasskey(): Promise<AuthProviderSession> {
+    return this.requireReadyProvider().linkPasskey();
+  }
+
   logout(): Promise<void> {
     return this.mountApi?.logout() ?? Promise.resolve();
   }
@@ -235,6 +239,8 @@ export class AuthProviderService implements OnDestroy {
       typeof value.sendEmailCode === 'function' &&
       'verifyEmailCode' in value &&
       typeof value.verifyEmailCode === 'function' &&
+      'linkPasskey' in value &&
+      typeof value.linkPasskey === 'function' &&
       'logout' in value &&
       typeof value.logout === 'function' &&
       'getAccessToken' in value &&

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -22,7 +22,14 @@ describe('AuthSessionService', () => {
     router = { navigateByUrl: jasmine.createSpy('navigateByUrl') };
     authProvider = jasmine.createSpyObj<AuthProviderService>(
       'AuthProviderService',
-      ['login', 'sendEmailCode', 'verifyEmailCode', 'logout', 'getAccessToken'],
+      [
+        'login',
+        'sendEmailCode',
+        'verifyEmailCode',
+        'linkPasskey',
+        'logout',
+        'getAccessToken',
+      ],
       {
         snapshot: {
           status: 'ready',
@@ -50,6 +57,17 @@ describe('AuthSessionService', () => {
         sessionId: 'session-1',
         email: 'user@example.com',
         authMethod: 'email',
+      },
+      wallets: [],
+    });
+    authProvider.linkPasskey.and.resolveTo({
+      user: {
+        id: 'account-1',
+        providerUserId: 'provider-user-1',
+        sessionId: 'session-1',
+        email: 'user@example.com',
+        authMethod: 'email',
+        passkeyEnabled: true,
       },
       wallets: [],
     });
@@ -131,6 +149,29 @@ describe('AuthSessionService', () => {
       wallets: [],
     });
     expect(service.session?.user.authMethod).toBe('email');
+  }));
+
+  it('enables passkey through the account provider and updates the session', fakeAsync(() => {
+    let resolvedSession: unknown;
+
+    service.enablePasskey().then(session => {
+      resolvedSession = session;
+    });
+    flushMicrotasks();
+
+    expect(authProvider.linkPasskey).toHaveBeenCalledTimes(1);
+    expect(resolvedSession).toEqual({
+      user: {
+        id: 'account-1',
+        providerUserId: 'provider-user-1',
+        sessionId: 'session-1',
+        email: 'user@example.com',
+        authMethod: 'email',
+        passkeyEnabled: true,
+      },
+      wallets: [],
+    });
+    expect(service.session?.user.passkeyEnabled).toBeTrue();
   }));
 
   it('logs out through the provider and clears host wallet state', fakeAsync(() => {

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -131,6 +131,22 @@ export class AuthSessionService {
     }
   }
 
+  async enablePasskey(): Promise<AuthSession> {
+    this.loadingSubject.next(true);
+    try {
+      const session = await this.authProvider.linkPasskey();
+      const token = await this.authProvider.getAccessToken();
+      if (!token) {
+        throw new Error('Account provider access token is unavailable');
+      }
+      this.accessToken = token;
+      this.sessionSubject.next(session);
+      return session;
+    } finally {
+      this.loadingSubject.next(false);
+    }
+  }
+
   async logout(): Promise<void> {
     this.loadingSubject.next(true);
     try {

--- a/src/app/core/auth/auth-session.types.ts
+++ b/src/app/core/auth/auth-session.types.ts
@@ -4,6 +4,7 @@ export type BackendUser = {
   sessionId: string;
   email?: string | null;
   authMethod?: string | null;
+  passkeyEnabled?: boolean;
 };
 
 export type BackendWallet = {

--- a/src/app/mfe-contracts/README.md
+++ b/src/app/mfe-contracts/README.md
@@ -20,7 +20,7 @@ Use this as the source of truth for runtime communication in the Angular app.
 The canonical, open runtime contract is
 `cs_mfe-wallets/src/contracts/auth-provider-contract.ts`. This host keeps only
 the structural consumer copy in `auth-provider.types.ts` and validates contract
-version `2.1.0` before mounting `mfe-wallets/auth-provider`.
+version `2.2.0` before mounting `mfe-wallets/auth-provider`.
 
 The wallet remote exposes atomized entrypoints:
 
@@ -32,6 +32,10 @@ The wallet remote exposes atomized entrypoints:
 Angular should continue to load only `./mount` and `./auth-provider`. It must
 not load `./providers/privy` directly unless provider ownership is intentionally
 moved into the host by a future contract change.
+
+Passkey enablement is consumed through the provider-neutral `linkPasskey()`
+contract method and the normalized `passkeyEnabled` user field. Angular must
+not inspect provider linked-account payloads or passkey credential IDs.
 
 The NestJS `GET /api/v1/public/auth-config` response is the single source of
 truth for enabled login methods and public provider configuration. `mfe-wallets`

--- a/src/app/mfe-contracts/auth-provider.types.ts
+++ b/src/app/mfe-contracts/auth-provider.types.ts
@@ -5,10 +5,10 @@
  * The wallet MFE is the single source of truth. Keep this copy compatible and
  * reject unsupported contract versions at runtime.
  */
-export type AuthProviderContractVersion = '2.1.0';
+export type AuthProviderContractVersion = '2.2.0';
 
 export const AUTH_PROVIDER_CONTRACT_VERSION: AuthProviderContractVersion =
-  '2.1.0';
+  '2.2.0';
 
 export type AuthProviderLoginMethod = 'email' | 'google' | 'apple' | 'passkey';
 
@@ -27,6 +27,7 @@ export type AuthProviderUser = {
   sessionId: string;
   email?: string | null;
   authMethod?: string | null;
+  passkeyEnabled?: boolean;
 };
 
 export type AuthProviderWallet = {
@@ -63,6 +64,7 @@ export type AuthProviderMountApi = {
   verifyEmailCode: (
     input: AuthProviderEmailCodeInput
   ) => Promise<AuthProviderSession>;
+  linkPasskey: () => Promise<AuthProviderSession>;
   logout: () => Promise<void>;
   getAccessToken: () => Promise<string | null>;
 };

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -45,6 +45,33 @@
 
     <section class="profile-shell__panel">
       <div class="profile-shell__panel-header">
+        <h2>Security</h2>
+        <span
+          class="profile-shell__primary"
+          *ngIf="activeSession.user.passkeyEnabled">
+          Passkey enabled
+        </span>
+      </div>
+      <p class="profile-shell__empty" *ngIf="activeSession.user.passkeyEnabled">
+        Use passkey authentication on your next sign in. Email code remains
+        available as a fallback.
+      </p>
+      <ng-container *ngIf="!activeSession.user.passkeyEnabled">
+        <p class="profile-shell__empty">
+          Enable passkey authentication for faster sign in.
+        </p>
+        <button
+          type="button"
+          mat-stroked-button
+          [disabled]="passkeyLoading || !canEnablePasskey()"
+          (click)="enablePasskey()">
+          Enable passkey
+        </button>
+      </ng-container>
+    </section>
+
+    <section class="profile-shell__panel">
+      <div class="profile-shell__panel-header">
         <h2>Wallets</h2>
         <button type="button" mat-button (click)="refreshWallets()">
           Refresh
@@ -129,6 +156,9 @@
   </p>
   <p class="profile-shell__message" *ngIf="balanceMessage">
     {{ balanceMessage }}
+  </p>
+  <p class="profile-shell__message" *ngIf="passkeyMessage">
+    {{ passkeyMessage }}
   </p>
   <p class="profile-shell__message" *ngIf="deletionMessage">
     {{ deletionMessage }}

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -18,8 +18,10 @@ export class ProfileComponent implements OnInit, OnDestroy {
   public deletionMessage = '';
   public walletMessage = '';
   public balanceMessage = '';
+  public passkeyMessage = '';
   public error = '';
   public busyWalletId = '';
+  public passkeyLoading = false;
   public balances: BackendBalance[] = [];
   public balancesLoading = false;
 
@@ -65,6 +67,25 @@ export class ProfileComponent implements OnInit, OnDestroy {
       ? 'cache'
       : `cache until ${expiry.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
     return `${this.shortAddress(balance.walletAddress)} / ${balance.chainType} / ${expiresAt}`;
+  }
+
+  public canEnablePasskey(): boolean {
+    return this.authSession.enabledLoginMethods.includes('passkey');
+  }
+
+  public async enablePasskey(): Promise<void> {
+    this.error = '';
+    this.passkeyMessage = '';
+    this.passkeyLoading = true;
+    try {
+      await this.authSession.enablePasskey();
+      this.passkeyMessage = 'Passkey authentication enabled';
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Passkey enablement failed';
+    } finally {
+      this.passkeyLoading = false;
+    }
   }
 
   public async refreshWallets(): Promise<void> {
@@ -146,6 +167,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
     this.walletMessage = '';
     this.balanceMessage = '';
     this.deletionMessage = '';
+    this.passkeyMessage = '';
     try {
       await this.authSession.logout();
     } catch (error) {


### PR DESCRIPTION
## Summary
- consume auth-provider contract 2.2.0
- add AuthSessionService.enablePasskey
- add Profile security panel for enabling passkey

## Verification
- ./node_modules/.bin/ng build --configuration development

## Notes
- focused Karma specs could not complete because ChromeHeadless needs a no-sandbox launcher when running as root in this environment
- repo-wide tsc is blocked by existing playwright.config.ts process.env.CI index-signature errors