### PR TITLE
release: wallet profile and passkey auth updates

### DIFF
--- a/e2e/shell-layout.spec.ts
+++ b/e2e/shell-layout.spec.ts
@@ -87,9 +87,11 @@ test.describe('Shell layout (desktop)', () => {
     expect(dividerBox.x).toBeLessThanOrEqual(sidebar.x + sidebar.width + 2);
   });
 
-  test('connect wallet control is visible in header', async ({ page }) => {
+  test('connect wallet control is not visible in header', async ({ page }) => {
     await expect(
-      page.getByRole('button', { name: /connect wallet/i }).first()
-    ).toBeVisible();
+      page
+        .locator('app-header')
+        .getByRole('button', { name: /connect wallet/i })
+    ).toHaveCount(0);
   });
 });

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,4 @@
 <app-layout>
   <router-outlet></router-outlet>
 </app-layout>
+<app-wallet-bar [showTrigger]="false" [hostModal]="true" />

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -14,7 +14,6 @@
         routerLinkActive="_active">
         {{ session ? 'Profile' : 'Sign in' }}
       </a>
-      <app-wallet-bar />
     </div>
   </div>
   <app-animate-line

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -10,9 +10,16 @@
     <div class="header__content_connect">
       <a
         class="header__account-link"
+        [class.header__account-link--icon]="session"
         [routerLink]="session ? '/profile' : '/login'"
-        routerLinkActive="_active">
-        {{ session ? 'Profile' : 'Sign in' }}
+        routerLinkActive="_active"
+        [attr.aria-label]="session ? 'Profile' : 'Sign in'"
+        [attr.title]="session ? 'Profile' : 'Sign in'">
+        @if (session) {
+          <mat-icon aria-hidden="true">person</mat-icon>
+        } @else {
+          Sign in
+        }
       </a>
     </div>
   </div>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -60,6 +60,22 @@
       text-decoration: none;
       white-space: nowrap;
 
+      &--icon {
+        width: 2.25rem;
+        min-width: 2.25rem;
+        height: 2.25rem;
+        min-height: 2.25rem;
+        padding: 0;
+        border-radius: 999px;
+      }
+
+      mat-icon {
+        width: 1.25rem;
+        height: 1.25rem;
+        font-size: 1.25rem;
+        line-height: 1.25rem;
+      }
+
       &._active {
         border-color: var(--primary-text-color);
         color: var(--primary-text-color);
@@ -94,8 +110,26 @@
 
     &__account-link {
       height: 2rem;
-      padding: 0 0.65rem;
-      font-size: 0.78rem;
+
+      &--icon {
+        width: 2rem;
+        min-width: 2rem;
+        height: 2rem;
+        min-height: 2rem;
+        padding: 0;
+      }
+
+      &:not(&--icon) {
+        padding: 0 0.65rem;
+        font-size: 0.78rem;
+      }
+
+      mat-icon {
+        width: 1.125rem;
+        height: 1.125rem;
+        font-size: 1.125rem;
+        line-height: 1.125rem;
+      }
     }
   }
 }

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,18 +1,23 @@
 @import '@vodis/ui-kit/styles/breakpoints';
 
 :host {
+  display: block;
+  height: var(--shell-header-height);
+
   .header {
     position: relative;
     display: flex;
-    height: var(--shell-header-height);
+    height: 100%;
     box-sizing: border-box;
     flex-direction: column;
 
     &__content {
       display: grid;
+      height: 100%;
       min-height: 0;
-      flex: 1;
+      box-sizing: border-box;
       align-items: center;
+      padding-bottom: 1px;
       grid-template-columns: repeat(7, minmax(0, 1fr));
     }
 
@@ -31,24 +36,27 @@
 
     &__content_connect {
       display: flex;
+      height: 100%;
       align-items: center;
       justify-content: flex-end;
       gap: 0.75rem;
-      padding-top: 6px;
-      padding-right: 1rem;
-      grid-column: 6 / 8;
+      padding-right: 1.5rem;
+      grid-column: 2 / 8;
     }
 
     &__account-link {
       display: inline-flex;
-      min-height: 2.25rem;
+      height: 2.25rem;
+      box-sizing: border-box;
       align-items: center;
+      justify-content: center;
       padding: 0 0.85rem;
       border: 1px solid rgb(255 255 255 / 18%);
       border-radius: 8px;
       color: var(--main-text-color);
       font-size: 0.85rem;
-      line-height: 1;
+      font-weight: 500;
+      line-height: 1.2;
       text-decoration: none;
       white-space: nowrap;
 
@@ -78,12 +86,14 @@
     }
 
     &__content_connect {
-      justify-content: center;
-      padding-top: 6px;
+      height: 100%;
+      justify-content: flex-end;
+      padding-right: 1rem;
       grid-column: 3 / 5;
     }
 
     &__account-link {
+      height: 2rem;
       padding: 0 0.65rem;
       font-size: 0.78rem;
     }

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,24 +1,40 @@
+/// <reference types="jasmine" />
+
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
 import { HeaderComponent } from './header.component';
 import { AuthSessionService } from '@core/auth/auth-session.service';
+import type { AuthSession } from '@core/auth/auth-session.types';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
-  beforeEach(() => {
+  const session: AuthSession = {
+    user: {
+      id: 'account-1',
+      providerUserId: 'provider-1',
+      sessionId: 'session-1',
+      email: 'user@example.com',
+      authMethod: 'email',
+      passkeyEnabled: false,
+    },
+    wallets: [],
+  };
+
+  function setup(sessionValue: AuthSession | null): void {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, MatIconModule],
       declarations: [HeaderComponent],
       providers: [
         {
           provide: AuthSessionService,
           useValue: {
-            session$: of(null),
+            session$: of(sessionValue),
           },
         },
       ],
@@ -27,9 +43,33 @@ describe('HeaderComponent', () => {
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }
 
   it('should create', () => {
+    setup(null);
     expect(component).toBeTruthy();
+  });
+
+  it('shows sign in text when logged out', () => {
+    setup(null);
+
+    const link = fixture.nativeElement.querySelector(
+      '.header__account-link'
+    ) as HTMLElement;
+
+    expect(link.textContent?.trim()).toBe('Sign in');
+    expect(link.classList.contains('header__account-link--icon')).toBeFalse();
+  });
+
+  it('shows account icon when logged in', () => {
+    setup(session);
+
+    const link = fixture.nativeElement.querySelector(
+      '.header__account-link'
+    ) as HTMLElement;
+
+    expect(link.getAttribute('aria-label')).toBe('Profile');
+    expect(link.classList.contains('header__account-link--icon')).toBeTrue();
+    expect(link.querySelector('mat-icon')?.textContent?.trim()).toBe('person');
   });
 });

--- a/src/app/core/auth/auth-provider.service.spec.ts
+++ b/src/app/core/auth/auth-provider.service.spec.ts
@@ -84,6 +84,9 @@ describe('AuthProviderService', () => {
     const api = mountApi({
       status: 'ready',
       loginMethods: ['email', 'passkey'],
+      passkeyLoginEnabled: true,
+      passkeySignupEnabled: false,
+      passkeyLinkEnabled: true,
       embeddedWalletEnabled: true,
     });
     const mountAuthProvider = jasmine
@@ -111,7 +114,14 @@ describe('AuthProviderService', () => {
       notifySubscribed = resolve;
     });
     const api = mountApi(
-      { status: 'loading', loginMethods: [], embeddedWalletEnabled: false },
+      {
+        status: 'loading',
+        loginMethods: [],
+        passkeyLoginEnabled: false,
+        passkeySignupEnabled: false,
+        passkeyLinkEnabled: false,
+        embeddedWalletEnabled: false,
+      },
       listener => {
         providerListener = listener;
         notifySubscribed?.();
@@ -126,6 +136,9 @@ describe('AuthProviderService', () => {
     providerListener?.({
       status: 'ready',
       loginMethods: ['passkey'],
+      passkeyLoginEnabled: true,
+      passkeySignupEnabled: false,
+      passkeyLinkEnabled: true,
       embeddedWalletEnabled: true,
     });
     expect((await initialized).status).toBe('ready');
@@ -135,6 +148,9 @@ describe('AuthProviderService', () => {
     const api = mountApi({
       status: 'disabled',
       loginMethods: [],
+      passkeyLoginEnabled: false,
+      passkeySignupEnabled: false,
+      passkeyLinkEnabled: false,
       embeddedWalletEnabled: false,
     });
     loader.and.resolveTo({ mountAuthProvider: () => api });

--- a/src/app/core/auth/auth-provider.service.ts
+++ b/src/app/core/auth/auth-provider.service.ts
@@ -20,6 +20,9 @@ const REMOTE_LOAD_TIMEOUT_MS = 15_000;
 const INITIAL_SNAPSHOT: AuthProviderSnapshot = {
   status: 'loading',
   loginMethods: [],
+  passkeyLoginEnabled: false,
+  passkeySignupEnabled: false,
+  passkeyLinkEnabled: false,
   embeddedWalletEnabled: false,
 };
 
@@ -157,6 +160,9 @@ export class AuthProviderService implements OnDestroy {
       return this.publish({
         status: 'failed',
         loginMethods: [],
+        passkeyLoginEnabled: false,
+        passkeySignupEnabled: false,
+        passkeyLinkEnabled: false,
         embeddedWalletEnabled: false,
         error: errorMessage,
       });
@@ -178,9 +184,24 @@ export class AuthProviderService implements OnDestroy {
         value.error === undefined ||
         typeof value.error === 'string')
     ) {
+      const passkeyLoginEnabled = this.optionalBoolean(
+        value,
+        'passkeyLoginEnabled',
+        value.loginMethods.includes('passkey')
+      );
+      const passkeySignupEnabled = false;
+      const passkeyLinkEnabled = this.optionalBoolean(
+        value,
+        'passkeyLinkEnabled',
+        value.loginMethods.includes('passkey')
+      );
+
       return {
         status: value.status,
         loginMethods: value.loginMethods,
+        passkeyLoginEnabled,
+        passkeySignupEnabled,
+        passkeyLinkEnabled,
         embeddedWalletEnabled: value.embeddedWalletEnabled,
         ...('error' in value && typeof value.error === 'string'
           ? { error: value.error }
@@ -191,9 +212,24 @@ export class AuthProviderService implements OnDestroy {
     return {
       status: 'failed',
       loginMethods: [],
+      passkeyLoginEnabled: false,
+      passkeySignupEnabled: false,
+      passkeyLinkEnabled: false,
       embeddedWalletEnabled: false,
       error: 'Account provider returned an invalid state.',
     };
+  }
+
+  private optionalBoolean(
+    value: object,
+    key: 'passkeyLoginEnabled' | 'passkeySignupEnabled' | 'passkeyLinkEnabled',
+    fallback: boolean
+  ): boolean {
+    const record = value as Record<string, unknown>;
+    if (!(key in value)) {
+      return fallback;
+    }
+    return typeof record[key] === 'boolean' ? record[key] : fallback;
   }
 
   private isProviderStatus(

--- a/src/app/core/auth/auth-provider.service.ts
+++ b/src/app/core/auth/auth-provider.service.ts
@@ -189,7 +189,6 @@ export class AuthProviderService implements OnDestroy {
         'passkeyLoginEnabled',
         value.loginMethods.includes('passkey')
       );
-      const passkeySignupEnabled = false;
       const passkeyLinkEnabled = this.optionalBoolean(
         value,
         'passkeyLinkEnabled',
@@ -200,7 +199,7 @@ export class AuthProviderService implements OnDestroy {
         status: value.status,
         loginMethods: value.loginMethods,
         passkeyLoginEnabled,
-        passkeySignupEnabled,
+        passkeySignupEnabled: false,
         passkeyLinkEnabled,
         embeddedWalletEnabled: value.embeddedWalletEnabled,
         ...('error' in value && typeof value.error === 'string'
@@ -222,7 +221,7 @@ export class AuthProviderService implements OnDestroy {
 
   private optionalBoolean(
     value: object,
-    key: 'passkeyLoginEnabled' | 'passkeySignupEnabled' | 'passkeyLinkEnabled',
+    key: 'passkeyLoginEnabled' | 'passkeyLinkEnabled',
     fallback: boolean
   ): boolean {
     const record = value as Record<string, unknown>;

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -36,6 +36,9 @@ describe('AuthSessionService', () => {
         snapshot: {
           status: 'ready',
           loginMethods: ['email', 'passkey'],
+          passkeyLoginEnabled: true,
+          passkeySignupEnabled: false,
+          passkeyLinkEnabled: true,
           embeddedWalletEnabled: true,
         },
       }

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -116,6 +116,10 @@ describe('AuthSessionService', () => {
     expect(service.enabledLoginMethods).toEqual(['email', 'passkey']);
   });
 
+  it('uses runtime passkey linking capability', () => {
+    expect(service.passkeyLinkEnabled).toBeTrue();
+  });
+
   it('logs in through the account provider without provider-specific host calls', fakeAsync(() => {
     let resolvedSession: unknown;
 

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -61,6 +61,17 @@ export class AuthSessionService {
     return methods.length > 0 ? methods : ['email'];
   }
 
+  get passkeyLoginEnabled(): boolean {
+    const snapshot = this.authProvider.snapshot;
+    return (
+      snapshot.passkeyLoginEnabled && snapshot.loginMethods.includes('passkey')
+    );
+  }
+
+  get passkeyLinkEnabled(): boolean {
+    return this.authProvider.snapshot.passkeyLinkEnabled;
+  }
+
   async refresh(): Promise<AuthSession | null> {
     const token = await this.currentAccessToken();
     if (!token) {

--- a/src/app/core/auth/auth.guard.spec.ts
+++ b/src/app/core/auth/auth.guard.spec.ts
@@ -32,6 +32,9 @@ describe('AuthGuard', () => {
           resolve({
             status: 'ready',
             loginMethods: ['email'],
+            passkeyLoginEnabled: false,
+            passkeySignupEnabled: false,
+            passkeyLinkEnabled: true,
             embeddedWalletEnabled: true,
           });
       })
@@ -62,6 +65,9 @@ describe('AuthGuard', () => {
     authProvider.whenSettled.and.resolveTo({
       status: 'disabled',
       loginMethods: [],
+      passkeyLoginEnabled: false,
+      passkeySignupEnabled: false,
+      passkeyLinkEnabled: false,
       embeddedWalletEnabled: false,
     });
 
@@ -77,6 +83,9 @@ describe('AuthGuard', () => {
     authProvider.whenSettled.and.resolveTo({
       status: 'failed',
       loginMethods: [],
+      passkeyLoginEnabled: false,
+      passkeySignupEnabled: false,
+      passkeyLinkEnabled: false,
       embeddedWalletEnabled: false,
     });
 

--- a/src/app/mfe-contracts/auth-provider.types.ts
+++ b/src/app/mfe-contracts/auth-provider.types.ts
@@ -17,6 +17,9 @@ export type AuthProviderStatus = 'loading' | 'ready' | 'disabled' | 'failed';
 export type AuthProviderSnapshot = {
   status: AuthProviderStatus;
   loginMethods: AuthProviderLoginMethod[];
+  passkeyLoginEnabled: boolean;
+  passkeySignupEnabled: boolean;
+  passkeyLinkEnabled: boolean;
   embeddedWalletEnabled: boolean;
   error?: string;
 };

--- a/src/app/pages/auth/login/login.component.spec.ts
+++ b/src/app/pages/auth/login/login.component.spec.ts
@@ -19,8 +19,13 @@ describe('LoginComponent', () => {
         providerSnapshot$: of({
           status: 'ready' as const,
           loginMethods: ['email', 'passkey', 'google', 'apple'],
+          passkeyLoginEnabled: true,
+          passkeySignupEnabled: false,
+          passkeyLinkEnabled: true,
           embeddedWalletEnabled: true,
         }),
+        enabledLoginMethods: ['email', 'passkey', 'google', 'apple'],
+        passkeyLoginEnabled: true,
       }
     );
     router = jasmine.createSpyObj('Router', ['navigateByUrl']);
@@ -72,6 +77,15 @@ describe('LoginComponent', () => {
       'apple',
       'telegram',
     ]);
+  });
+
+  it('hides passkey when passkey login is disabled', () => {
+    Object.defineProperty(authSession, 'passkeyLoginEnabled', {
+      configurable: true,
+      get: () => false,
+    });
+
+    expect(component.socialMethods).toEqual(['google', 'apple', 'telegram']);
   });
 
   it('shows a coming soon message for telegram login', async () => {

--- a/src/app/pages/auth/login/login.component.ts
+++ b/src/app/pages/auth/login/login.component.ts
@@ -28,7 +28,18 @@ export class LoginComponent {
   public error = '';
   public info = '';
 
-  public readonly socialMethods = LOGIN_SOCIAL_METHODS;
+  public get socialMethods(): AuthSocialMethod[] {
+    const loginMethods = new Set(this.authSession.enabledLoginMethods);
+    return LOGIN_SOCIAL_METHODS.filter(method => {
+      if (method === 'telegram') {
+        return true;
+      }
+      if (method === 'passkey') {
+        return this.authSession.passkeyLoginEnabled;
+      }
+      return loginMethods.has(method);
+    });
+  }
 
   constructor(
     public readonly authSession: AuthSessionService,

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -46,17 +46,34 @@
     <section class="profile-shell__panel">
       <div class="profile-shell__panel-header">
         <h2>Security</h2>
-        <span
-          class="profile-shell__primary"
-          *ngIf="activeSession.user.passkeyEnabled">
-          Passkey enabled
-        </span>
       </div>
-      <p class="profile-shell__empty" *ngIf="activeSession.user.passkeyEnabled">
-        Use passkey authentication on your next sign in. Email code remains
-        available as a fallback.
-      </p>
-      <ng-container *ngIf="!activeSession.user.passkeyEnabled">
+
+      <div
+        class="profile-shell__passkey"
+        *ngIf="activeSession.user.passkeyEnabled; else passkeyDisabled">
+        <div
+          class="profile-shell__passkey-status profile-shell__passkey-status--enabled">
+          <span class="profile-shell__passkey-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false">
+              <path
+                fill="currentColor"
+                d="M12 12a3.25 3.25 0 1 0 0-6.5 3.25 3.25 0 0 0 0 6.5Zm-7 7.25v-1.1c0-2.2 3.13-3.65 7-3.65s7 1.45 7 3.65v1.1H5Z" />
+              <path
+                fill="currentColor"
+                d="M18.2 8.4a.75.75 0 0 1 1.06 0l1.34 1.34a3.25 3.25 0 0 1 0 4.6l-.47.47a.75.75 0 0 1-1.06-1.06l.47-.47a1.75 1.75 0 0 0 0-2.47l-1.34-1.34a.75.75 0 0 1 0-1.06Z" />
+            </svg>
+          </span>
+          <div class="profile-shell__passkey-copy">
+            <span class="profile-shell__passkey-label">Passkey enabled</span>
+            <p class="profile-shell__empty">
+              Use passkey authentication on your next sign in. Email code
+              remains available as a fallback.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <ng-template #passkeyDisabled>
         <p class="profile-shell__empty">
           Enable passkey authentication for faster sign in.
         </p>
@@ -67,7 +84,7 @@
           (click)="enablePasskey()">
           Enable passkey
         </button>
-      </ng-container>
+      </ng-template>
     </section>
 
     <section class="profile-shell__panel">

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -77,7 +77,9 @@
           Refresh
         </button>
       </div>
-      <app-wallet-bar />
+      <div class="profile-shell__wallet-connect">
+        <app-wallet-bar />
+      </div>
       <div
         class="profile-shell__empty"
         *ngIf="activeSession.wallets.length === 0">

--- a/src/app/pages/auth/profile/profile.component.scss
+++ b/src/app/pages/auth/profile/profile.component.scss
@@ -183,6 +183,59 @@
     line-height: 1rem;
   }
 
+  &__passkey {
+    display: grid;
+    gap: 1rem;
+  }
+
+  &__passkey-status {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+  }
+
+  &__passkey-status--enabled {
+    .profile-shell__passkey-icon {
+      color: var(--success, #7ee787);
+      background: rgb(126 231 135 / 12%);
+      border-color: rgb(126 231 135 / 28%);
+    }
+
+    .profile-shell__passkey-label {
+      color: var(--success, #7ee787);
+    }
+  }
+
+  &__passkey-icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    width: 2.5rem;
+    height: 2.5rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgb(255 255 255 / 14%);
+    border-radius: 999px;
+    background: rgb(255 255 255 / 4%);
+
+    svg {
+      display: block;
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  }
+
+  &__passkey-copy {
+    display: grid;
+    min-width: 0;
+    gap: 0.35rem;
+  }
+
+  &__passkey-label {
+    font-size: 0.92rem;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
   &__empty,
   &__message,
   &__error {

--- a/src/app/pages/auth/profile/profile.component.scss
+++ b/src/app/pages/auth/profile/profile.component.scss
@@ -72,6 +72,10 @@
     }
   }
 
+  &__wallet-connect {
+    margin: 0 0 1rem;
+  }
+
   dl {
     display: grid;
     margin: 0;

--- a/src/app/pages/auth/profile/profile.component.spec.ts
+++ b/src/app/pages/auth/profile/profile.component.spec.ts
@@ -1,0 +1,76 @@
+/// <reference types="jasmine" />
+
+import { BehaviorSubject, of } from 'rxjs';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import type { AuthSession } from '@core/auth/auth-session.types';
+import { ProfileComponent } from './profile.component';
+
+describe('ProfileComponent', () => {
+  let component: ProfileComponent;
+  let authSession: jasmine.SpyObj<AuthSessionService>;
+  let sessionSubject: BehaviorSubject<AuthSession | null>;
+
+  const enabledSession: AuthSession = {
+    user: {
+      id: 'account-1',
+      providerUserId: 'provider-1',
+      sessionId: 'session-1',
+      email: 'user@example.com',
+      authMethod: 'email',
+      passkeyEnabled: true,
+    },
+    wallets: [],
+  };
+
+  const disabledSession: AuthSession = {
+    user: {
+      ...enabledSession.user,
+      passkeyEnabled: false,
+    },
+    wallets: [],
+  };
+
+  beforeEach(() => {
+    sessionSubject = new BehaviorSubject<AuthSession | null>(disabledSession);
+    authSession = jasmine.createSpyObj<AuthSessionService>(
+      'AuthSessionService',
+      [
+        'enablePasskey',
+        'reloadWallets',
+        'loadBalances',
+        'setPrimaryWallet',
+        'deleteWallet',
+        'requestDeletion',
+        'logout',
+      ],
+      {
+        session$: sessionSubject.asObservable(),
+        loading$: of(false),
+        passkeyLinkEnabled: true,
+      }
+    );
+    authSession.enablePasskey.and.resolveTo(enabledSession);
+    authSession.loadBalances.and.resolveTo([]);
+
+    component = new ProfileComponent(authSession);
+    component.ngOnInit();
+  });
+
+  it('allows enabling passkey when it is not enabled', async () => {
+    expect(component.canEnablePasskey()).toBeTrue();
+
+    await component.enablePasskey();
+
+    expect(authSession.enablePasskey).toHaveBeenCalledTimes(1);
+    expect(component.passkeyMessage).toBe('Passkey authentication enabled');
+  });
+
+  it('hides passkey enablement when linking is disabled', () => {
+    Object.defineProperty(authSession, 'passkeyLinkEnabled', {
+      configurable: true,
+      get: () => false,
+    });
+
+    expect(component.canEnablePasskey()).toBeFalse();
+  });
+});

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -70,7 +70,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
   }
 
   public canEnablePasskey(): boolean {
-    return this.authSession.enabledLoginMethods.includes('passkey');
+    return this.authSession.passkeyLinkEnabled;
   }
 
   public async enablePasskey(): Promise<void> {

--- a/src/app/pages/auth/register/register.component.spec.ts
+++ b/src/app/pages/auth/register/register.component.spec.ts
@@ -21,6 +21,9 @@ describe('RegisterComponent', () => {
         providerSnapshot$: of({
           status: 'ready' as const,
           loginMethods: ['email' as const],
+          passkeyLoginEnabled: false,
+          passkeySignupEnabled: false,
+          passkeyLinkEnabled: true,
           embeddedWalletEnabled: true,
         }),
       }

--- a/src/app/shared/components/wallet-bar/wallet-bar.component.html
+++ b/src/app/shared/components/wallet-bar/wallet-bar.component.html
@@ -1,21 +1,25 @@
 <div class="wallet-bar">
-  @if (!account) {
-    <button
-      (click)="handleOpenWalletMenu()"
-      mat-stroked-button
-      color="primary"
-      class="btn-lg">
-      Connect wallet
-    </button>
-  } @else {
-    <app-wallet-menu
-      [account]="account"
-      (accountClick)="handleOpenWalletMenu()" />
+  @if (showTrigger) {
+    @if (!account) {
+      <button
+        (click)="handleOpenWalletMenu()"
+        mat-stroked-button
+        color="primary"
+        class="btn-lg">
+        Connect wallet
+      </button>
+    } @else {
+      <app-wallet-menu
+        [account]="account"
+        (accountClick)="handleOpenWalletMenu()" />
+    }
   }
 
-  <app-side-modal
-    [isOpen]="isOpenWalletConnectMenu"
-    (closeRequested)="handleCloseWalletMenu()">
-    <app-wallets />
-  </app-side-modal>
+  @if (hostModal) {
+    <app-side-modal
+      [isOpen]="isOpenWalletConnectMenu"
+      (closeRequested)="handleCloseWalletMenu()">
+      <app-wallets />
+    </app-side-modal>
+  }
 </div>

--- a/src/app/shared/components/wallet-bar/wallet-bar.component.ts
+++ b/src/app/shared/components/wallet-bar/wallet-bar.component.ts
@@ -1,8 +1,7 @@
-import { Component } from '@angular/core';
-import { WalletsService } from '@shared/mfe/wallets/wallets.service';
-import { WalletAccount } from '@domains/wallet/models/wallet.models';
+import { Component, DestroyRef, inject, Input } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DestroyRef, inject } from '@angular/core';
+import { WalletAccount } from '@domains/wallet/models/wallet.models';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 
 @Component({
   selector: 'app-wallet-bar',
@@ -11,17 +10,21 @@ import { DestroyRef, inject } from '@angular/core';
   styleUrls: [],
 })
 export class WalletBarComponent {
+  @Input() showTrigger = true;
+  @Input() hostModal = false;
+
   private readonly destroyRef = inject(DestroyRef);
+  private readonly walletsService = inject(WalletsService);
   public isOpenWalletConnectMenu = false;
   public account: WalletAccount | undefined;
 
-  constructor(private walletsService: WalletsService) {
+  constructor() {
     this.walletsService.account
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(account => {
         const hadAccount = Boolean(this.account?.account);
         this.account = account;
-        if (account && !hadAccount) {
+        if (this.hostModal && account && !hadAccount) {
           this.isOpenWalletConnectMenu = false;
         }
       });
@@ -29,7 +32,7 @@ export class WalletBarComponent {
     this.walletsService.closeRequested
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(closeRequested => {
-        if (closeRequested) {
+        if (this.hostModal && closeRequested) {
           this.isOpenWalletConnectMenu = false;
           this.walletsService.clearCloseRequest();
         }
@@ -38,7 +41,7 @@ export class WalletBarComponent {
     this.walletsService.openRequested
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(openRequested => {
-        if (openRequested) {
+        if (this.hostModal && openRequested) {
           this.isOpenWalletConnectMenu = true;
           this.walletsService.clearOpenRequest();
         }
@@ -46,7 +49,12 @@ export class WalletBarComponent {
   }
 
   public handleOpenWalletMenu(): void {
-    this.isOpenWalletConnectMenu = true;
+    if (this.hostModal) {
+      this.isOpenWalletConnectMenu = true;
+      return;
+    }
+
+    this.walletsService.requestOpen();
   }
 
   public handleCloseWalletMenu(): void {


### PR DESCRIPTION
## Summary
- Move wallet connection entry points out of the header and host the wallet modal at the app shell/profile flow.
- Replace the signed-in header Profile text button with an account icon treatment.
- Align passkey auth capabilities with the backend/MFE contract: passkey login is gated separately from authenticated passkey enrollment, and passkey signup remains disabled.
- Show passkey enabled state on the profile page and keep enrollment controlled by the provider passkey-link capability.

## Included PRs
- #136 feat: move connect wallet to profile
- #140 feat: replace profile button with account icon in header
- #142 fix: passkey auth capabilities
- #141 feat(profile): show passkey enabled state

## Validation
- TypeScript / ESLint: passing
- Angular tests: passing
- Shell layout E2E tests: passing
- Production build: passing
- pr-checks: passing