### PR TITLE
release: align login flow, wallet onboarding, and session redirects

### DIFF
--- a/ARCHITECTURE_GUIDE.md
+++ b/ARCHITECTURE_GUIDE.md
@@ -296,3 +296,71 @@ For every new feature, answer:
 7. Which communication channel(s) are touched and what version changes are needed?
 
 If these answers are not explicit, implementation should not start.
+
+## 15. Authentication and Session Flow
+
+The host owns top-level auth routing and session restoration. The wallet MFE owns
+provider login, passkey linking, and wallet modal workflows.
+
+### Public routes
+
+| Route       | Purpose                |
+| ----------- | ---------------------- |
+| `/login`    | Returning-user sign in |
+| `/register` | New account creation   |
+
+Both routes render outside the main shell (no header/sidebar). Route prefixes are
+owned in `src/app/core/routing/auth-shell.routes.ts` and applied by
+`LayoutComponent` via `*ngIf` — do not duplicate them in `index.html`.
+
+### Protected routes
+
+| Route              | Guard       | Purpose                                           |
+| ------------------ | ----------- | ------------------------------------------------- |
+| `/profile`         | `AuthGuard` | Account settings, passkey enablement, wallet list |
+| `/generate-wallet` | `AuthGuard` | First-time wallet onboarding after auth           |
+
+### Login methods on `/login`
+
+The login page always offers these social entry points:
+
+- Passkey
+- Google
+- Apple
+- Telegram
+
+Email code login remains available as a fallback form.
+
+Passkey UX rule:
+
+- Passkey is always visible on `/login`.
+- If the user has not enabled passkey in profile yet, the host maps provider
+  errors to a friendly message that directs them to sign in with Google, Apple,
+  or Telegram first, then enable passkey from `/profile`.
+
+### Session policy
+
+`AuthGuard` behavior:
+
+1. Allow navigation when `AuthSessionService.session` is already populated.
+2. Otherwise wait for the auth provider to reach a terminal state.
+3. Attempt `AuthSessionService.refresh()` when the provider is `ready`.
+4. Redirect to `/login?returnUrl=<safe-path>` when there is no valid session and
+   refresh cannot restore one.
+
+Logout clears host session state and navigates to `/login`.
+
+### Post-auth wallet onboarding
+
+Account creation or login without linked wallets does not enter the dApp
+immediately. The host routes to `/generate-wallet?returnUrl=<safe-path>`.
+
+`/generate-wallet` owns first-time wallet setup:
+
+- Connect existing wallet (opens wallets MFE modal)
+- Generate embedded wallet (host bridge into wallets MFE)
+- Continue after wallet is connected
+
+`/profile` does not duplicate generate-wallet UI. It renders a Connect wallet
+button that opens the wallets MFE modal, which already contains generate/link
+flows for returning users.

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -192,3 +192,46 @@ Update this guide and `AGENT_GUIDE.md` whenever one of the following changes:
 - Host/MFE communication contract.
 - Wallet integration lifecycle or routing behavior.
 - Required local run/test commands.
+
+## Authentication Routes and UX
+
+Host auth routes live under `src/app/pages/auth/`.
+
+| Route              | Access      | Notes                                                              |
+| ------------------ | ----------- | ------------------------------------------------------------------ |
+| `/login`           | Public      | Passkey, Google, Apple, Telegram always shown; email code fallback |
+| `/register`        | Public      | Account creation only; wallet setup is separate                    |
+| `/generate-wallet` | `AuthGuard` | First wallet onboarding after auth                                 |
+| `/profile`         | `AuthGuard` | Passkey enablement + Connect wallet button                         |
+
+### Login expectations
+
+- `/login` always renders Passkey, Google, Apple, and Telegram buttons.
+- Passkey remains visible even when the account has not enabled passkey yet.
+- When passkey sign-in fails because passkey is not enabled in profile, show a
+  UX message that tells the user to sign in with Google, Apple, or Telegram
+  first and enable passkey from profile.
+- Telegram may remain a staged provider; keep the button visible and show a
+  coming-soon/info state until the provider is wired.
+
+### Session redirect policy
+
+- Missing or non-renewable sessions redirect to `/login?returnUrl=<safe-path>`.
+- `AuthGuard` waits for auth-provider readiness before attempting refresh.
+- Logout navigates to `/login`.
+
+### Wallet onboarding split
+
+- `/generate-wallet` is the dedicated first-time setup page after register/login
+  when the account has no linked wallets.
+- `/profile` renders only a Connect wallet trigger (`app-wallet-bar`). Generate
+  wallet and external-wallet linking remain inside the wallets MFE modal.
+- Do not re-implement generate-wallet UI in profile; reuse the MFE modal flow.
+
+### Local validation for auth changes
+
+1. Start host and wallets MFE together.
+2. Verify `/login` social buttons and passkey-not-enabled messaging.
+3. Verify protected-route redirect to `/login` without a session.
+4. Verify register/login without wallets routes to `/generate-wallet`.
+5. Verify profile Connect wallet opens the wallets MFE modal.

--- a/e2e/helpers/shell-layout.ts
+++ b/e2e/helpers/shell-layout.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { useAuthenticatedSession } from '../utils/auth-fixtures';
 
 export const SHELL_HEADER_HEIGHT_PX = 64;
 export const DESKTOP_GRID_COLUMNS = 7;
@@ -9,6 +10,7 @@ export function exchangeIntroHeading(page: Page): Locator {
 }
 
 export async function gotoExchangePage(page: Page): Promise<void> {
+  await useAuthenticatedSession(page);
   await page.goto('/');
 
   // Shell renders on bootstrap; home route is lazy-loaded in CI production builds.

--- a/e2e/utils/auth-fixtures.ts
+++ b/e2e/utils/auth-fixtures.ts
@@ -1,0 +1,184 @@
+import type { Page } from '@playwright/test';
+
+const AUTH_PROVIDER_REMOTE_ENTRY_URL =
+  'https://wallets.craftscript.com/remoteEntry.js';
+const API_BASE_URL = 'https://api.craftscript.com';
+const E2E_ACCESS_TOKEN = 'e2e-access-token';
+const CROSS_ORIGIN_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+};
+
+export type E2eAuthUser = {
+  id: string;
+  providerUserId: string;
+  sessionId: string;
+  email?: string | null;
+  authMethod?: string | null;
+  passkeyEnabled?: boolean;
+};
+
+export type E2eAuthWallet = {
+  id: string;
+  providerWalletId: string;
+  address: string;
+  chainType: string;
+  walletType: string;
+  source?: string;
+  status?: string;
+  isPrimary: boolean;
+  deletedAt?: string | null;
+};
+
+export type E2eAuthenticatedSession = {
+  user: E2eAuthUser;
+  wallets: E2eAuthWallet[];
+  accessToken: string;
+};
+
+const DEFAULT_AUTHENTICATED_SESSION: E2eAuthenticatedSession = {
+  user: {
+    id: 'e2e-user',
+    providerUserId: 'e2e-provider-user',
+    sessionId: 'e2e-session',
+    email: 'e2e@craftscript.test',
+    authMethod: 'email',
+    passkeyEnabled: false,
+  },
+  wallets: [
+    {
+      id: 'e2e-wallet',
+      providerWalletId: 'e2e-provider-wallet',
+      address: '0x0000000000000000000000000000000000000001',
+      chainType: 'evm',
+      walletType: 'embedded',
+      source: 'e2e',
+      status: 'active',
+      isPrimary: true,
+      deletedAt: null,
+    },
+  ],
+  accessToken: E2E_ACCESS_TOKEN,
+};
+
+export async function useAuthenticatedSession(
+  page: Page,
+  session: E2eAuthenticatedSession = DEFAULT_AUTHENTICATED_SESSION
+): Promise<void> {
+  await mockAuthProviderRemote(page, session);
+  await mockAuthSessionApi(page, session);
+}
+
+async function mockAuthProviderRemote(
+  page: Page,
+  session: E2eAuthenticatedSession
+): Promise<void> {
+  await page.route(AUTH_PROVIDER_REMOTE_ENTRY_URL, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      headers: CROSS_ORIGIN_HEADERS,
+      body: createAuthProviderRemoteEntry(session),
+    })
+  );
+}
+
+async function mockAuthSessionApi(
+  page: Page,
+  session: E2eAuthenticatedSession
+): Promise<void> {
+  await page.route(`${API_BASE_URL}/api/v1/me`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: CROSS_ORIGIN_HEADERS,
+      body: JSON.stringify({ user: session.user }),
+    })
+  );
+
+  await page.route(`${API_BASE_URL}/api/v1/wallets`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: CROSS_ORIGIN_HEADERS,
+      body: JSON.stringify({ wallets: session.wallets }),
+    })
+  );
+}
+
+function createAuthProviderRemoteEntry(
+  session: E2eAuthenticatedSession
+): string {
+  const serializedSession = JSON.stringify({
+    user: session.user,
+    wallets: session.wallets,
+  });
+  const serializedAccessToken = JSON.stringify(session.accessToken);
+
+  return `
+const snapshot = {
+  status: 'ready',
+  loginMethods: ['email'],
+  passkeyLoginEnabled: false,
+  passkeySignupEnabled: false,
+  passkeyLinkEnabled: false,
+  embeddedWalletEnabled: true
+};
+const session = ${serializedSession};
+const walletSnapshot = {
+  status: 'disconnected',
+  account: null,
+  chainId: null,
+  isVerified: false,
+  safetyStatus: null,
+  isBypassed: false,
+  executionState: 'operating.idle'
+};
+const modules = {
+  'auth-provider': {
+    mountAuthProvider: function () {
+      return {
+        contractVersion: '2.2.0',
+        unmount: function () {},
+        subscribe: function (listener) {
+          queueMicrotask(function () { listener(snapshot); });
+          return function () {};
+        },
+        getSnapshot: function () { return snapshot; },
+        login: function () { return Promise.resolve(session); },
+        sendEmailCode: function () { return Promise.resolve(); },
+        verifyEmailCode: function () { return Promise.resolve(session); },
+        linkPasskey: function () { return Promise.resolve(session); },
+        logout: function () { return Promise.resolve(); },
+        getAccessToken: function () {
+          return Promise.resolve(${serializedAccessToken});
+        }
+      };
+    }
+  },
+  'mount': {
+    mount: function () {
+      return {
+        unmount: function () {},
+        subscribe: function () { return function () {}; },
+        getSnapshot: function () { return walletSnapshot; },
+        disconnectWallet: function () {},
+        sendGatewayEvent: function () {}
+      };
+    }
+  }
+};
+
+export function init() {
+  return Promise.resolve();
+}
+
+export function get(exposedModule) {
+  const key = exposedModule.replace(/^\\.\\//, '');
+  const module = modules[key];
+  if (!module) {
+    return Promise.reject(new Error('Unknown e2e remote module: ' + exposedModule));
+  }
+  return Promise.resolve(function () { return module; });
+}
+`;
+}

--- a/src/app/components/layout/layout.component.spec.ts
+++ b/src/app/components/layout/layout.component.spec.ts
@@ -12,7 +12,6 @@ describe('LayoutComponent', () => {
 
   beforeEach(() => {
     routerEvents = new Subject();
-    document.documentElement.classList.remove('auth-shell-route');
 
     TestBed.configureTestingModule({
       declarations: [LayoutComponent],
@@ -32,23 +31,19 @@ describe('LayoutComponent', () => {
     fixture.detectChanges();
   });
 
-  afterEach(() => {
-    document.documentElement.classList.remove('auth-shell-route');
-  });
-
   it('hides shell on auth routes when navigation completes', () => {
     routerEvents.next(new NavigationEnd(1, '/login', '/login'));
 
     expect(component.hideShell).toBeTrue();
-    expect(
-      document.documentElement.classList.contains('auth-shell-route')
-    ).toBeTrue();
 
-    routerEvents.next(new NavigationEnd(2, '/', '/'));
+    routerEvents.next(
+      new NavigationEnd(2, '/generate-wallet', '/generate-wallet')
+    );
+
+    expect(component.hideShell).toBeTrue();
+
+    routerEvents.next(new NavigationEnd(3, '/', '/'));
 
     expect(component.hideShell).toBeFalse();
-    expect(
-      document.documentElement.classList.contains('auth-shell-route')
-    ).toBeFalse();
   });
 });

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -11,6 +11,7 @@ import {
 import { NavigationEnd, Router } from '@angular/router';
 import { Direction } from '@shared/components/animate-line/animate-line.component';
 import { filter, Subscription } from 'rxjs';
+import { isAuthShellRoute } from '@core/routing/auth-shell.routes';
 
 @Component({
   selector: 'app-layout',
@@ -28,7 +29,7 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   public verticalLineAnimating = true;
   public contentHeight: number | null = null;
   public lineResetKey = 0;
-  public hideShell = LayoutComponent.shouldHideShell(window.location.pathname);
+  public hideShell = isAuthShellRoute(window.location.pathname);
 
   private resizeObserver?: ResizeObserver;
   private routerSubscription?: Subscription;
@@ -40,7 +41,6 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public ngOnInit(): void {
     this.isMobileView = this.currentWidth <= 768;
-    LayoutComponent.syncAuthShellRouteClass(this.hideShell);
 
     this.routerSubscription = this.router.events
       .pipe(filter(event => event instanceof NavigationEnd))
@@ -102,16 +102,6 @@ export class LayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private updateShellVisibility(url: string): void {
-    this.hideShell = LayoutComponent.shouldHideShell(url);
-    LayoutComponent.syncAuthShellRouteClass(this.hideShell);
-  }
-
-  private static syncAuthShellRouteClass(hideShell: boolean): void {
-    document.documentElement.classList.toggle('auth-shell-route', hideShell);
-  }
-
-  private static shouldHideShell(url: string): boolean {
-    const path = url.split('?')[0].split('#')[0];
-    return path.startsWith('/register') || path.startsWith('/login');
+    this.hideShell = isAuthShellRoute(url);
   }
 }

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -204,7 +204,7 @@ describe('AuthSessionService', () => {
     expect(walletGatewayBridge.disconnectWallet).toHaveBeenCalledTimes(1);
     expect(walletsService.setAccount).toHaveBeenCalledOnceWith(undefined);
     expect(service.session).toBeNull();
-    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/register');
+    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/login');
   }));
 
   it('refreshes session and wallets using the provider access token', fakeAsync(() => {

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -186,7 +186,7 @@ export class AuthSessionService {
       this.walletGatewayBridge.disconnectWallet();
       this.walletsService.setAccount(undefined);
       this.clear();
-      await this.router.navigateByUrl('/register');
+      await this.router.navigateByUrl('/login');
     } finally {
       this.loadingSubject.next(false);
     }

--- a/src/app/core/auth/auth.guard.spec.ts
+++ b/src/app/core/auth/auth.guard.spec.ts
@@ -74,7 +74,7 @@ describe('AuthGuard', () => {
     await guard.canActivate({} as never, { url: '/farm' } as never);
 
     expect(authSession.refresh).not.toHaveBeenCalled();
-    expect(router.createUrlTree).toHaveBeenCalledOnceWith(['/register'], {
+    expect(router.createUrlTree).toHaveBeenCalledOnceWith(['/login'], {
       queryParams: { returnUrl: '/farm' },
     });
   });
@@ -91,7 +91,7 @@ describe('AuthGuard', () => {
 
     await guard.canActivate({} as never, { url: '//example.test' } as never);
 
-    expect(router.createUrlTree).toHaveBeenCalledOnceWith(['/register'], {
+    expect(router.createUrlTree).toHaveBeenCalledOnceWith(['/login'], {
       queryParams: { returnUrl: '/' },
     });
   });

--- a/src/app/core/auth/auth.guard.ts
+++ b/src/app/core/auth/auth.guard.ts
@@ -30,7 +30,7 @@ export class AuthGuard implements CanActivate {
       provider.status === 'ready' ? await this.authSession.refresh() : null;
     return session
       ? true
-      : this.router.createUrlTree(['/register'], {
+      : this.router.createUrlTree(['/login'], {
           queryParams: { returnUrl: this.safeReturnUrl(state.url) },
         });
   }

--- a/src/app/core/product-events/product-events.service.ts
+++ b/src/app/core/product-events/product-events.service.ts
@@ -75,11 +75,16 @@ export class ProductEventsService {
       : `anon-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   }
 
-  private sanitizeMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  private sanitizeMetadata(
+    metadata: Record<string, unknown>
+  ): Record<string, unknown> {
     const denied = ['token', 'authorization', 'password', 'secret'];
     return Object.fromEntries(
       Object.entries(metadata)
-        .filter(([key]) => !denied.some(deniedKey => key.toLowerCase().includes(deniedKey)))
+        .filter(
+          ([key]) =>
+            !denied.some(deniedKey => key.toLowerCase().includes(deniedKey))
+        )
         .slice(0, 40)
     );
   }
@@ -108,6 +113,8 @@ export class ProductEventsService {
     url: string,
     status: number | 'network_error'
   ): void {
-    console.warn(`product telemetry delivery failed url=${url} status=${status}`);
+    console.warn(
+      `product telemetry delivery failed url=${url} status=${status}`
+    );
   }
 }

--- a/src/app/core/routing/auth-shell.routes.spec.ts
+++ b/src/app/core/routing/auth-shell.routes.spec.ts
@@ -1,0 +1,22 @@
+import {
+  AUTH_SHELL_ROUTE_PREFIXES,
+  isAuthShellRoute,
+} from './auth-shell.routes';
+
+describe('auth-shell.routes', () => {
+  it('lists the auth shell route prefixes', () => {
+    expect(AUTH_SHELL_ROUTE_PREFIXES).toEqual([
+      '/login',
+      '/register',
+      '/generate-wallet',
+    ]);
+  });
+
+  it('detects auth shell routes from a pathname', () => {
+    expect(isAuthShellRoute('/login')).toBeTrue();
+    expect(isAuthShellRoute('/register?returnUrl=/')).toBeTrue();
+    expect(isAuthShellRoute('/generate-wallet')).toBeTrue();
+    expect(isAuthShellRoute('/profile')).toBeFalse();
+    expect(isAuthShellRoute('//evil.example')).toBeFalse();
+  });
+});

--- a/src/app/core/routing/auth-shell.routes.ts
+++ b/src/app/core/routing/auth-shell.routes.ts
@@ -1,0 +1,10 @@
+export const AUTH_SHELL_ROUTE_PREFIXES = [
+  '/login',
+  '/register',
+  '/generate-wallet',
+] as const;
+
+export function isAuthShellRoute(url: string): boolean {
+  const path = url.split('?')[0].split('#')[0];
+  return AUTH_SHELL_ROUTE_PREFIXES.some(prefix => path.startsWith(prefix));
+}

--- a/src/app/pages/auth/auth-routing.module.ts
+++ b/src/app/pages/auth/auth-routing.module.ts
@@ -4,6 +4,7 @@ import { LoginComponent } from './login/login.component';
 import { ProfileComponent } from './profile/profile.component';
 import { AuthGuard } from '@core/auth/auth.guard';
 import { RegisterComponent } from './register/register.component';
+import { GenerateWalletComponent } from './generate-wallet/generate-wallet.component';
 
 const routes: Routes = [
   {
@@ -13,6 +14,11 @@ const routes: Routes = [
   {
     path: 'register',
     component: RegisterComponent,
+  },
+  {
+    path: 'generate-wallet',
+    component: GenerateWalletComponent,
+    canActivate: [AuthGuard],
   },
   {
     path: 'profile',

--- a/src/app/pages/auth/auth.module.ts
+++ b/src/app/pages/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { AuthRoutingModule } from './auth-routing.module';
 import { LoginComponent } from './login/login.component';
 import { ProfileComponent } from './profile/profile.component';
 import { RegisterComponent } from './register/register.component';
+import { GenerateWalletComponent } from './generate-wallet/generate-wallet.component';
 import { AuthSocialButtonsComponent } from './shared/auth-social-buttons.component';
 
 @NgModule({
@@ -12,6 +13,7 @@ import { AuthSocialButtonsComponent } from './shared/auth-social-buttons.compone
     LoginComponent,
     ProfileComponent,
     RegisterComponent,
+    GenerateWalletComponent,
     AuthSocialButtonsComponent,
   ],
 })

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.html
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.html
@@ -1,0 +1,67 @@
+<section class="register-shell register-shell--centered" @authPageTransition>
+  <div class="register-shell__content">
+    <section class="register-shell__panel">
+      <div class="register-shell__brand">
+        <img
+          src="../../../assets/img/logo/logo.svg"
+          alt="CraftScript"
+          width="40"
+          height="40" />
+        <span>CraftScript</span>
+      </div>
+
+      <h2>Set up wallet</h2>
+
+      <ng-container *ngIf="authSession.providerSnapshot$ | async as provider">
+        <p
+          class="register-shell__status"
+          *ngIf="provider.status === 'disabled'">
+          Wallet setup is not enabled for this environment.
+        </p>
+        <p class="register-shell__status" *ngIf="provider.status === 'failed'">
+          {{ provider.error || 'Wallet setup is temporarily unavailable.' }}
+        </p>
+
+        <div
+          class="register-shell__wallet-step"
+          *ngIf="provider.status === 'ready'">
+          <p>
+            Link a wallet before entering the dApp. You can connect an existing
+            wallet or create an embedded wallet secured by your account.
+          </p>
+
+          <button
+            class="register-shell__wallet-action"
+            type="button"
+            [disabled]="walletLoading"
+            (click)="connectExistingWallet()">
+            Connect existing wallet
+          </button>
+          <button
+            class="register-shell__wallet-action register-shell__wallet-action--primary"
+            type="button"
+            [disabled]="walletLoading"
+            (click)="generateWallet()">
+            Generate wallet
+          </button>
+          <button
+            class="register-shell__wallet-refresh"
+            type="button"
+            [disabled]="walletLoading"
+            (click)="finishAfterWalletLinked()">
+            Continue after wallet is connected
+          </button>
+        </div>
+      </ng-container>
+
+      <p class="register-shell__error" *ngIf="error">{{ error }}</p>
+      <p class="register-shell__info-note" *ngIf="info">{{ info }}</p>
+
+      <app-side-modal
+        [isOpen]="isOpenWalletConnectMenu"
+        (closeRequested)="closeWalletConnectMenu()">
+        <app-wallets />
+      </app-side-modal>
+    </section>
+  </div>
+</section>

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.scss
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.scss
@@ -1,4 +1,3 @@
 :host {
   display: block;
-  min-width: 0;
 }

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.spec.ts
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.spec.ts
@@ -1,0 +1,129 @@
+import { convertToParamMap, ParamMap, Router } from '@angular/router';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
+import { of } from 'rxjs';
+import { GenerateWalletComponent } from './generate-wallet.component';
+
+describe('GenerateWalletComponent', () => {
+  let component: GenerateWalletComponent;
+  let authSession: jasmine.SpyObj<AuthSessionService>;
+  let router: jasmine.SpyObj<Router>;
+  let walletsService: jasmine.SpyObj<WalletsService>;
+  let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
+  let queryParamMap: ParamMap;
+
+  beforeEach(() => {
+    authSession = jasmine.createSpyObj<AuthSessionService>(
+      'AuthSessionService',
+      ['reloadWallets'],
+      {
+        session: {
+          user: {
+            id: 'account-1',
+            providerUserId: 'provider-user-1',
+            sessionId: 'session-1',
+          },
+          wallets: [],
+        },
+        providerSnapshot$: of({
+          status: 'ready' as const,
+          loginMethods: ['email' as const],
+          passkeyLoginEnabled: false,
+          passkeySignupEnabled: false,
+          passkeyLinkEnabled: true,
+          embeddedWalletEnabled: true,
+        }),
+      }
+    );
+    router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
+    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
+      'requestOpen',
+    ]);
+    walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
+      'WalletGatewayBridgeService',
+      ['createEmbeddedWallet']
+    );
+    queryParamMap = convertToParamMap({});
+    router.navigateByUrl.and.resolveTo(true);
+    authSession.reloadWallets.and.resolveTo([]);
+
+    component = new GenerateWalletComponent(
+      authSession,
+      router,
+      { snapshot: { queryParamMap } } as never,
+      walletsService,
+      walletGatewayBridge
+    );
+  });
+
+  it('opens the wallet connector from the page', () => {
+    component.connectExistingWallet();
+
+    expect(component.isOpenWalletConnectMenu).toBeTrue();
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates an embedded wallet and navigates after backend wallet refresh', async () => {
+    queryParamMap = convertToParamMap({ returnUrl: '//evil.example' });
+    component = createComponent();
+    walletGatewayBridge.createEmbeddedWallet.and.resolveTo({
+      account: '0x1111111111111111111111111111111111111111',
+      chainId: 1,
+      walletType: 'embedded',
+      source: 'provider',
+    });
+    authSession.reloadWallets.and.resolveTo([
+      {
+        id: 'wallet-1',
+        providerWalletId: 'wallet-1',
+        address: '0x1111111111111111111111111111111111111111',
+        chainType: 'ethereum',
+        walletType: 'embedded',
+        isPrimary: true,
+      },
+    ]);
+
+    await component.generateWallet();
+
+    expect(walletGatewayBridge.createEmbeddedWallet).toHaveBeenCalledTimes(1);
+    expect(authSession.reloadWallets).toHaveBeenCalledTimes(1);
+    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/');
+  });
+
+  it('requires a linked wallet before continuing', async () => {
+    await component.finishAfterWalletLinked();
+
+    expect(component.error).toBe('Connect or generate a wallet to continue.');
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('redirects away when wallets already exist', async () => {
+    queryParamMap = convertToParamMap({ returnUrl: '/farm' });
+    component = createComponent();
+    authSession.reloadWallets.and.resolveTo([
+      {
+        id: 'wallet-1',
+        providerWalletId: 'wallet-1',
+        address: '0x1111111111111111111111111111111111111111',
+        chainType: 'ethereum',
+        walletType: 'embedded',
+        isPrimary: true,
+      },
+    ]);
+
+    await component.ngOnInit();
+
+    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/farm');
+  });
+
+  function createComponent(): GenerateWalletComponent {
+    return new GenerateWalletComponent(
+      authSession,
+      router,
+      { snapshot: { queryParamMap } } as never,
+      walletsService,
+      walletGatewayBridge
+    );
+  }
+});

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.ts
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
+import { authPageTransition } from '../shared/auth-page.animations';
+import {
+  hasLinkedWallets,
+  readReturnUrl,
+} from '../shared/auth-navigation.helper';
+
+@Component({
+  selector: 'app-generate-wallet',
+  standalone: false,
+  templateUrl: './generate-wallet.component.html',
+  styleUrls: ['./generate-wallet.component.scss'],
+  animations: [authPageTransition],
+})
+export class GenerateWalletComponent implements OnInit {
+  public walletLoading = false;
+  public isOpenWalletConnectMenu = false;
+  public error = '';
+  public info = '';
+
+  constructor(
+    public readonly authSession: AuthSessionService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute,
+    private readonly walletsService: WalletsService,
+    private readonly walletGatewayBridge: WalletGatewayBridgeService
+  ) {}
+
+  public async ngOnInit(): Promise<void> {
+    const session = this.authSession.session;
+    if (!session) {
+      return;
+    }
+
+    if (await hasLinkedWallets(this.authSession, session.wallets.length)) {
+      await this.router.navigateByUrl(
+        readReturnUrl(this.route.snapshot.queryParamMap)
+      );
+    }
+  }
+
+  public connectExistingWallet(): void {
+    this.error = '';
+    this.info = '';
+    this.isOpenWalletConnectMenu = true;
+    this.walletsService.requestOpen();
+  }
+
+  public closeWalletConnectMenu(): void {
+    this.isOpenWalletConnectMenu = false;
+  }
+
+  public async generateWallet(): Promise<void> {
+    this.error = '';
+    this.info = '';
+    this.walletLoading = true;
+
+    try {
+      await this.walletGatewayBridge.createEmbeddedWallet();
+      const wallets = await this.authSession.reloadWallets();
+      if (wallets.length === 0) {
+        throw new Error(
+          'Wallet was created but profile refresh returned no wallets.'
+        );
+      }
+      await this.router.navigateByUrl(
+        readReturnUrl(this.route.snapshot.queryParamMap)
+      );
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Wallet setup failed';
+    } finally {
+      this.walletLoading = false;
+    }
+  }
+
+  public async finishAfterWalletLinked(): Promise<void> {
+    this.error = '';
+    this.info = '';
+    this.walletLoading = true;
+
+    try {
+      const wallets = await this.authSession.reloadWallets();
+      if (wallets.length === 0) {
+        this.error = 'Connect or generate a wallet to continue.';
+        return;
+      }
+      await this.router.navigateByUrl(
+        readReturnUrl(this.route.snapshot.queryParamMap)
+      );
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Wallet refresh failed';
+    } finally {
+      this.walletLoading = false;
+    }
+  }
+}

--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -56,8 +56,19 @@
             <app-auth-social-buttons
               [disabled]="provider.status !== 'ready' || loading"
               [methods]="socialMethods"
+              [disabledMethods]="
+                disabledSocialMethods(provider.passkeyLoginEnabled)
+              "
               (methodSelected)="continueWithSocial($event)">
             </app-auth-social-buttons>
+
+            <p
+              class="register-shell__info-note"
+              *ngIf="
+                showPasskeyLoginUnavailableNote(provider.passkeyLoginEnabled)
+              ">
+              {{ passkeyLoginUnavailableNote }}
+            </p>
           </div>
         </ng-container>
       </ng-container>

--- a/src/app/pages/auth/login/login.component.spec.ts
+++ b/src/app/pages/auth/login/login.component.spec.ts
@@ -1,20 +1,30 @@
 import { convertToParamMap, ParamMap } from '@angular/router';
 import { AuthSessionService } from '@core/auth/auth-session.service';
+import { ProductEventsService } from '@core/product-events/product-events.service';
 import { of } from 'rxjs';
+import {
+  PASSKEY_LOGIN_UNAVAILABLE_MESSAGE,
+  PASSKEY_SETUP_REQUIRED_MESSAGE,
+} from '../shared/auth-login-messages.helper';
 import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let authSession: jasmine.SpyObj<AuthSessionService>;
+  let productEvents: jasmine.SpyObj<ProductEventsService>;
   let router: jasmine.SpyObj<{
     navigateByUrl: (url: string) => Promise<boolean>;
+    navigate: (
+      commands: string[],
+      extras?: { queryParams?: Record<string, string> }
+    ) => Promise<boolean>;
   }>;
   let queryParamMap: ParamMap;
 
   beforeEach(() => {
     authSession = jasmine.createSpyObj<AuthSessionService>(
       'AuthSessionService',
-      ['login'],
+      ['login', 'sendEmailCode', 'verifyEmailCode', 'reloadWallets'],
       {
         providerSnapshot$: of({
           status: 'ready' as const,
@@ -28,22 +38,46 @@ describe('LoginComponent', () => {
         passkeyLoginEnabled: true,
       }
     );
-    router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+    router = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
     queryParamMap = convertToParamMap({});
     router.navigateByUrl.and.resolveTo(true);
+    router.navigate.and.resolveTo(true);
     authSession.login.and.resolveTo({
       user: {
         id: 'account-1',
         providerUserId: 'provider-user-1',
         sessionId: 'session-1',
       },
-      wallets: [],
+      wallets: [
+        {
+          id: 'wallet-1',
+          providerWalletId: 'wallet-1',
+          address: '0x1111111111111111111111111111111111111111',
+          chainType: 'ethereum',
+          walletType: 'embedded',
+          isPrimary: true,
+        },
+      ],
     });
+    authSession.reloadWallets.and.resolveTo([]);
+    productEvents = jasmine.createSpyObj<ProductEventsService>(
+      'ProductEventsService',
+      ['reason']
+    );
+    productEvents.reason.and.callFake((error: unknown) =>
+      error instanceof Error
+        ? error.message
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+        : 'unknown'
+    );
 
     component = new LoginComponent(
       authSession,
       router as never,
-      { snapshot: { queryParamMap } } as never
+      { snapshot: { queryParamMap } } as never,
+      productEvents
     );
   });
 
@@ -70,7 +104,7 @@ describe('LoginComponent', () => {
     expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/farm');
   });
 
-  it('shows passkey, google, apple, and telegram social options', () => {
+  it('shows passkey, google, apple, and telegram social options by default', () => {
     expect(component.socialMethods).toEqual([
       'passkey',
       'google',
@@ -79,13 +113,60 @@ describe('LoginComponent', () => {
     ]);
   });
 
-  it('hides passkey when passkey login is disabled', () => {
+  it('hides provider-backed social options when they are not enabled', () => {
+    Object.defineProperty(authSession, 'enabledLoginMethods', {
+      configurable: true,
+      get: () => ['email'],
+    });
+
+    expect(component.socialMethods).toEqual(['telegram']);
+  });
+
+  it('shows a helpful message when passkey is not enabled on the account', async () => {
+    authSession.login.and.rejectWith(new Error('No passkey credentials found'));
+
+    await component.continueWith('passkey');
+
+    expect(component.error).toBe(PASSKEY_SETUP_REQUIRED_MESSAGE);
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('shows an availability message when passkey login is disabled', async () => {
     Object.defineProperty(authSession, 'passkeyLoginEnabled', {
       configurable: true,
       get: () => false,
     });
+    component = createComponent();
 
-    expect(component.socialMethods).toEqual(['google', 'apple', 'telegram']);
+    await component.continueWithSocial('passkey');
+
+    expect(component.info).toBe(PASSKEY_LOGIN_UNAVAILABLE_MESSAGE);
+    expect(authSession.login).not.toHaveBeenCalled();
+  });
+
+  it('disables passkey when provider login capability is off', () => {
+    expect(component.disabledSocialMethods(false)).toEqual(['passkey']);
+    expect(component.disabledSocialMethods(true)).toEqual([]);
+    expect(component.showPasskeyLoginUnavailableNote(false)).toBeTrue();
+  });
+
+  it('routes wallet-less logins to generate-wallet', async () => {
+    authSession.login.and.resolveTo({
+      user: {
+        id: 'account-1',
+        providerUserId: 'provider-user-1',
+        sessionId: 'session-1',
+      },
+      wallets: [],
+    });
+    authSession.reloadWallets.and.resolveTo([]);
+
+    await component.continueWith('google');
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/generate-wallet'], {
+      queryParams: { returnUrl: '/' },
+    });
   });
 
   it('shows a coming soon message for telegram login', async () => {
@@ -99,7 +180,8 @@ describe('LoginComponent', () => {
     return new LoginComponent(
       authSession,
       router as never,
-      { snapshot: { queryParamMap } } as never
+      { snapshot: { queryParamMap } } as never,
+      productEvents
     );
   }
 });

--- a/src/app/pages/auth/login/login.component.ts
+++ b/src/app/pages/auth/login/login.component.ts
@@ -4,6 +4,15 @@ import { AuthSessionService } from '@core/auth/auth-session.service';
 import type { LoginMethod } from '@core/auth/auth-session.types';
 import type { AuthSocialMethod } from '../shared/auth-social-buttons.component';
 import { authPageTransition } from '../shared/auth-page.animations';
+import {
+  hasLinkedWallets,
+  readReturnUrl,
+} from '../shared/auth-navigation.helper';
+import {
+  resolveLoginError,
+  PASSKEY_LOGIN_UNAVAILABLE_MESSAGE,
+} from '../shared/auth-login-messages.helper';
+import { ProductEventsService } from '@core/product-events/product-events.service';
 
 const LOGIN_SOCIAL_METHODS: AuthSocialMethod[] = [
   'passkey',
@@ -30,21 +39,30 @@ export class LoginComponent {
 
   public get socialMethods(): AuthSocialMethod[] {
     const loginMethods = new Set(this.authSession.enabledLoginMethods);
-    return LOGIN_SOCIAL_METHODS.filter(method => {
-      if (method === 'telegram') {
-        return true;
-      }
-      if (method === 'passkey') {
-        return this.authSession.passkeyLoginEnabled;
-      }
-      return loginMethods.has(method);
-    });
+    return LOGIN_SOCIAL_METHODS.filter(
+      method => method === 'telegram' || loginMethods.has(method)
+    );
   }
+
+  public disabledSocialMethods(
+    providerPasskeyLoginEnabled: boolean
+  ): AuthSocialMethod[] {
+    return providerPasskeyLoginEnabled ? [] : ['passkey'];
+  }
+
+  public showPasskeyLoginUnavailableNote(
+    providerPasskeyLoginEnabled: boolean
+  ): boolean {
+    return !providerPasskeyLoginEnabled;
+  }
+
+  public passkeyLoginUnavailableNote = PASSKEY_LOGIN_UNAVAILABLE_MESSAGE;
 
   constructor(
     public readonly authSession: AuthSessionService,
     private readonly router: Router,
-    private readonly route: ActivatedRoute
+    private readonly route: ActivatedRoute,
+    private readonly productEvents: ProductEventsService
   ) {}
 
   public async loginWithEmail(): Promise<void> {
@@ -85,6 +103,11 @@ export class LoginComponent {
       return;
     }
 
+    if (method === 'passkey' && !this.authSession.passkeyLoginEnabled) {
+      this.info = PASSKEY_LOGIN_UNAVAILABLE_MESSAGE;
+      return;
+    }
+
     await this.continueWith(method);
   }
 
@@ -94,10 +117,12 @@ export class LoginComponent {
     this.loading = true;
 
     try {
-      await this.authSession.login(method);
-      await this.router.navigateByUrl(this.returnUrl());
+      const session = await this.authSession.login(method);
+      await this.navigateAfterAuth(session.wallets.length);
     } catch (error) {
-      this.error = error instanceof Error ? error.message : 'Login failed';
+      this.error = resolveLoginError(method, error, {
+        reasonCode: this.productEvents.reason(error),
+      });
     } finally {
       this.loading = false;
     }
@@ -114,13 +139,13 @@ export class LoginComponent {
 
     this.loading = true;
     try {
-      await this.authSession.verifyEmailCode(
+      const session = await this.authSession.verifyEmailCode(
         this.codeEmail,
         this.emailCode.trim()
       );
       this.isOpenEmailCodeModal = false;
       this.emailCode = '';
-      await this.router.navigateByUrl(this.returnUrl());
+      await this.navigateAfterAuth(session.wallets.length);
     } catch (error) {
       this.error =
         error instanceof Error ? error.message : 'Verification failed';
@@ -153,10 +178,18 @@ export class LoginComponent {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
   }
 
-  private returnUrl(): string {
-    const value = this.route.snapshot.queryParamMap.get('returnUrl');
-    return value && value.startsWith('/') && !value.startsWith('//')
-      ? value
-      : '/';
+  private async navigateAfterAuth(initialWalletCount: number): Promise<void> {
+    if (await hasLinkedWallets(this.authSession, initialWalletCount)) {
+      await this.router.navigateByUrl(
+        readReturnUrl(this.route.snapshot.queryParamMap)
+      );
+      return;
+    }
+
+    await this.router.navigate(['/generate-wallet'], {
+      queryParams: {
+        returnUrl: readReturnUrl(this.route.snapshot.queryParamMap),
+      },
+    });
   }
 }

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -50,7 +50,10 @@
 
       <div
         class="profile-shell__passkey"
-        *ngIf="activeSession.user.passkeyEnabled; else passkeyDisabled">
+        *ngIf="
+          isPasskeyLinked() && isPasskeyLoginAvailable();
+          else passkeyLinkedOnly
+        ">
         <div
           class="profile-shell__passkey-status profile-shell__passkey-status--enabled">
           <span class="profile-shell__passkey-icon" aria-hidden="true">
@@ -72,6 +75,33 @@
           </div>
         </div>
       </div>
+
+      <ng-template #passkeyLinkedOnly>
+        <div
+          class="profile-shell__passkey"
+          *ngIf="isPasskeyLinked(); else passkeyDisabled">
+          <div class="profile-shell__passkey-status">
+            <span class="profile-shell__passkey-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M12 12a3.25 3.25 0 1 0 0-6.5 3.25 3.25 0 0 0 0 6.5Zm-7 7.25v-1.1c0-2.2 3.13-3.65 7-3.65s7 1.45 7 3.65v1.1H5Z" />
+                <path
+                  fill="currentColor"
+                  d="M18.2 8.4a.75.75 0 0 1 1.06 0l1.34 1.34a3.25 3.25 0 0 1 0 4.6l-.47.47a.75.75 0 0 1-1.06-1.06l.47-.47a1.75 1.75 0 0 0 0-2.47l-1.34-1.34a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+            </span>
+            <div class="profile-shell__passkey-copy">
+              <span class="profile-shell__passkey-label">Passkey linked</span>
+              <p class="profile-shell__empty">
+                Your account has a passkey, but passkey sign-in is not enabled
+                in this environment yet. Continue signing in with email, Google,
+                or Apple.
+              </p>
+            </div>
+          </div>
+        </div>
+      </ng-template>
 
       <ng-template #passkeyDisabled>
         <p class="profile-shell__empty">
@@ -95,12 +125,15 @@
         </button>
       </div>
       <div class="profile-shell__wallet-connect">
+        <p class="profile-shell__empty">
+          Connect a wallet to link or create one through the wallet modal.
+        </p>
         <app-wallet-bar />
       </div>
       <div
         class="profile-shell__empty"
         *ngIf="activeSession.wallets.length === 0">
-        No wallet linked.
+        No wallet linked yet.
       </div>
       <ul
         class="profile-shell__wallets"

--- a/src/app/pages/auth/profile/profile.component.spec.ts
+++ b/src/app/pages/auth/profile/profile.component.spec.ts
@@ -47,6 +47,7 @@ describe('ProfileComponent', () => {
         session$: sessionSubject.asObservable(),
         loading$: of(false),
         passkeyLinkEnabled: true,
+        passkeyLoginEnabled: true,
       }
     );
     authSession.enablePasskey.and.resolveTo(enabledSession);
@@ -72,5 +73,16 @@ describe('ProfileComponent', () => {
     });
 
     expect(component.canEnablePasskey()).toBeFalse();
+  });
+
+  it('shows linked-only messaging when passkey login is unavailable', () => {
+    sessionSubject.next(enabledSession);
+    Object.defineProperty(authSession, 'passkeyLoginEnabled', {
+      configurable: true,
+      get: () => false,
+    });
+
+    expect(component.isPasskeyLinked()).toBeTrue();
+    expect(component.isPasskeyLoginAvailable()).toBeFalse();
   });
 });

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -73,6 +73,14 @@ export class ProfileComponent implements OnInit, OnDestroy {
     return this.authSession.passkeyLinkEnabled;
   }
 
+  public isPasskeyLinked(): boolean {
+    return this.session?.user.passkeyEnabled === true;
+  }
+
+  public isPasskeyLoginAvailable(): boolean {
+    return this.authSession.passkeyLoginEnabled;
+  }
+
   public async enablePasskey(): Promise<void> {
     this.error = '';
     this.passkeyMessage = '';

--- a/src/app/pages/auth/register/register.component.html
+++ b/src/app/pages/auth/register/register.component.html
@@ -26,9 +26,7 @@
         <span>CraftScript</span>
       </div>
 
-      <h2>
-        {{ step === 'account' ? 'Welcome to CraftScript' : 'Set up wallet' }}
-      </h2>
+      <h2>Welcome to CraftScript</h2>
 
       <ng-container *ngIf="authSession.providerSnapshot$ | async as provider">
         <p
@@ -42,92 +40,57 @@
           }}
         </p>
 
-        <ng-container *ngIf="step === 'account'">
-          <ng-container
-            *ngIf="
-              provider.status === 'loading' || provider.status === 'ready'
+        <ng-container
+          *ngIf="provider.status === 'loading' || provider.status === 'ready'">
+          <div
+            class="register-shell__form-block"
+            [class.register-shell__form-block--pending]="
+              provider.status !== 'ready' || loading
             ">
-            <div
-              class="register-shell__form-block"
-              [class.register-shell__form-block--pending]="
-                provider.status !== 'ready' || loading
-              ">
-              <form
-                class="register-shell__form"
-                (ngSubmit)="registerWithEmail()"
-                novalidate>
-                <label for="register-email">Email</label>
+            <form
+              class="register-shell__form"
+              (ngSubmit)="registerWithEmail()"
+              novalidate>
+              <label for="register-email">Email</label>
+              <input
+                id="register-email"
+                name="email"
+                type="email"
+                placeholder="name@example.com"
+                [(ngModel)]="email"
+                [disabled]="provider.status !== 'ready' || loading" />
+
+              <label class="register-shell__policy">
                 <input
-                  id="register-email"
-                  name="email"
-                  type="email"
-                  placeholder="name@example.com"
-                  [(ngModel)]="email"
+                  type="checkbox"
+                  name="policy"
+                  [(ngModel)]="agreedToPolicy"
                   [disabled]="provider.status !== 'ready' || loading" />
+                <span>
+                  By creating an account, I agree to CraftScript's
+                  <a href="/policy">Terms</a>.
+                </span>
+              </label>
 
-                <label class="register-shell__policy">
-                  <input
-                    type="checkbox"
-                    name="policy"
-                    [(ngModel)]="agreedToPolicy"
-                    [disabled]="provider.status !== 'ready' || loading" />
-                  <span>
-                    By creating an account, I agree to CraftScript's
-                    <a href="/policy">Terms</a>.
-                  </span>
-                </label>
+              <button
+                type="submit"
+                [disabled]="provider.status !== 'ready' || loading">
+                Register
+              </button>
+            </form>
 
-                <button
-                  type="submit"
-                  [disabled]="provider.status !== 'ready' || loading">
-                  Register
-                </button>
-              </form>
-
-              <div class="register-shell__divider">
-                <span>or</span>
-              </div>
-
-              <app-auth-social-buttons
-                [disabled]="provider.status !== 'ready' || loading"
-                [methods]="['google', 'apple', 'telegram']"
-                (methodSelected)="
-                  continueWithSocial($event)
-                "></app-auth-social-buttons>
+            <div class="register-shell__divider">
+              <span>or</span>
             </div>
-          </ng-container>
+
+            <app-auth-social-buttons
+              [disabled]="provider.status !== 'ready' || loading"
+              [methods]="['google', 'apple', 'telegram']"
+              (methodSelected)="
+                continueWithSocial($event)
+              "></app-auth-social-buttons>
+          </div>
         </ng-container>
-
-        <div
-          class="register-shell__wallet-step"
-          *ngIf="provider.status === 'ready' && step === 'wallet'">
-          <p>
-            Link a wallet before entering the dApp. You can connect an existing
-            wallet or create an embedded wallet secured by your account.
-          </p>
-
-          <button
-            class="register-shell__wallet-action"
-            type="button"
-            [disabled]="walletLoading"
-            (click)="connectExistingWallet()">
-            Connect existing wallet
-          </button>
-          <button
-            class="register-shell__wallet-action register-shell__wallet-action--primary"
-            type="button"
-            [disabled]="walletLoading"
-            (click)="generateWallet()">
-            Generate wallet
-          </button>
-          <button
-            class="register-shell__wallet-refresh"
-            type="button"
-            [disabled]="walletLoading"
-            (click)="finishAfterWalletLinked()">
-            Continue after wallet is connected
-          </button>
-        </div>
       </ng-container>
 
       <p class="register-shell__error" *ngIf="error">{{ error }}</p>
@@ -136,12 +99,6 @@
       <p class="register-shell__login-link">
         Already have an account? <a routerLink="/login">Log in</a>
       </p>
-
-      <app-side-modal
-        [isOpen]="isOpenWalletConnectMenu"
-        (closeRequested)="closeWalletConnectMenu()">
-        <app-wallets />
-      </app-side-modal>
 
       <app-side-modal
         [isOpen]="isOpenEmailCodeModal"

--- a/src/app/pages/auth/register/register.component.spec.ts
+++ b/src/app/pages/auth/register/register.component.spec.ts
@@ -1,7 +1,5 @@
 import { convertToParamMap, ParamMap, Router } from '@angular/router';
 import { AuthSessionService } from '@core/auth/auth-session.service';
-import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
-import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import { of } from 'rxjs';
 import { RegisterComponent } from './register.component';
 
@@ -9,8 +7,6 @@ describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let authSession: jasmine.SpyObj<AuthSessionService>;
   let router: jasmine.SpyObj<Router>;
-  let walletsService: jasmine.SpyObj<WalletsService>;
-  let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
   let queryParamMap: ParamMap;
 
   beforeEach(() => {
@@ -39,24 +35,18 @@ describe('RegisterComponent', () => {
       },
       wallets: [],
     });
-    router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
-    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
-      'requestOpen',
+    router = jasmine.createSpyObj<Router>('Router', [
+      'navigateByUrl',
+      'navigate',
     ]);
-    walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
-      'WalletGatewayBridgeService',
-      ['createEmbeddedWallet']
-    );
     queryParamMap = convertToParamMap({});
     router.navigateByUrl.and.resolveTo(true);
+    router.navigate.and.resolveTo(true);
+    authSession.reloadWallets.and.resolveTo([]);
 
-    component = new RegisterComponent(
-      authSession,
-      router,
-      { snapshot: { queryParamMap } } as never,
-      walletsService,
-      walletGatewayBridge
-    );
+    component = new RegisterComponent(authSession, router, {
+      snapshot: { queryParamMap },
+    } as never);
   });
 
   it('requires a valid email and accepted policy before email registration', async () => {
@@ -91,10 +81,9 @@ describe('RegisterComponent', () => {
     expect(component.isOpenEmailCodeModal).toBeTrue();
   });
 
-  it('verifies email code and moves to wallet setup when no wallets exist', async () => {
+  it('routes verified accounts without wallets to generate-wallet', async () => {
     component.codeEmail = 'user@example.com';
     component.emailCode = '123456';
-    authSession.reloadWallets.and.resolveTo([]);
 
     await component.verifyEmailCode();
 
@@ -103,7 +92,9 @@ describe('RegisterComponent', () => {
       '123456'
     );
     expect(component.isOpenEmailCodeModal).toBeFalse();
-    expect(component.step).toBe('wallet');
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/generate-wallet'], {
+      queryParams: { returnUrl: '/' },
+    });
   });
 
   it('navigates to a safe return URL when login already has wallets', async () => {
@@ -135,7 +126,7 @@ describe('RegisterComponent', () => {
     expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/farm');
   });
 
-  it('moves to the wallet step when login and refresh return no wallets', async () => {
+  it('routes wallet-less social registration to generate-wallet', async () => {
     component.agreedToPolicy = true;
     authSession.login.and.resolveTo({
       user: {
@@ -145,68 +136,18 @@ describe('RegisterComponent', () => {
       },
       wallets: [],
     });
-    authSession.reloadWallets.and.resolveTo([]);
 
     await component.continueWith('apple');
 
     expect(authSession.reloadWallets).toHaveBeenCalledTimes(1);
-    expect(component.step).toBe('wallet');
-    expect(component.info).toBe(
-      'Choose how you want to secure your wallet access.'
-    );
-    expect(router.navigateByUrl).not.toHaveBeenCalled();
-  });
-
-  it('opens the wallet connector from the wallet step', () => {
-    component.connectExistingWallet();
-
-    expect(component.isOpenWalletConnectMenu).toBeTrue();
-    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
-  });
-
-  it('generates an embedded wallet and navigates after backend wallet refresh', async () => {
-    queryParamMap = convertToParamMap({ returnUrl: '//evil.example' });
-    component = createComponent();
-    walletGatewayBridge.createEmbeddedWallet.and.resolveTo({
-      account: '0x1111111111111111111111111111111111111111',
-      chainId: 1,
-      walletType: 'embedded',
-      source: 'provider',
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/generate-wallet'], {
+      queryParams: { returnUrl: '/' },
     });
-    authSession.reloadWallets.and.resolveTo([
-      {
-        id: 'wallet-1',
-        providerWalletId: 'wallet-1',
-        address: '0x1111111111111111111111111111111111111111',
-        chainType: 'ethereum',
-        walletType: 'embedded',
-        isPrimary: true,
-      },
-    ]);
-
-    await component.generateWallet();
-
-    expect(walletGatewayBridge.createEmbeddedWallet).toHaveBeenCalledTimes(1);
-    expect(authSession.reloadWallets).toHaveBeenCalledTimes(1);
-    expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/');
-  });
-
-  it('requires a linked wallet before finishing wallet onboarding', async () => {
-    authSession.reloadWallets.and.resolveTo([]);
-
-    await component.finishAfterWalletLinked();
-
-    expect(component.error).toBe('Connect or generate a wallet to continue.');
-    expect(router.navigateByUrl).not.toHaveBeenCalled();
   });
 
   function createComponent(): RegisterComponent {
-    return new RegisterComponent(
-      authSession,
-      router,
-      { snapshot: { queryParamMap } } as never,
-      walletsService,
-      walletGatewayBridge
-    );
+    return new RegisterComponent(authSession, router, {
+      snapshot: { queryParamMap },
+    } as never);
   }
 });

--- a/src/app/pages/auth/register/register.component.ts
+++ b/src/app/pages/auth/register/register.component.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthSessionService } from '@core/auth/auth-session.service';
-import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
-import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import type { LoginMethod } from '@core/auth/auth-session.types';
 import type { AuthSocialMethod } from '../shared/auth-social-buttons.component';
 import { authPageTransition } from '../shared/auth-page.animations';
-
-type RegisterStep = 'account' | 'wallet';
+import {
+  hasLinkedWallets,
+  readReturnUrl,
+} from '../shared/auth-navigation.helper';
 
 @Component({
   selector: 'app-register',
@@ -20,21 +20,16 @@ export class RegisterComponent {
   public email = '';
   public agreedToPolicy = false;
   public loading = false;
-  public walletLoading = false;
-  public isOpenWalletConnectMenu = false;
   public isOpenEmailCodeModal = false;
   public emailCode = '';
   public codeEmail = '';
-  public step: RegisterStep = 'account';
   public error = '';
   public info = '';
 
   constructor(
     public readonly authSession: AuthSessionService,
     private readonly router: Router,
-    private readonly route: ActivatedRoute,
-    private readonly walletsService: WalletsService,
-    private readonly walletGatewayBridge: WalletGatewayBridgeService
+    private readonly route: ActivatedRoute
   ) {}
 
   public async registerWithEmail(): Promise<void> {
@@ -88,13 +83,7 @@ export class RegisterComponent {
       );
       this.isOpenEmailCodeModal = false;
       this.emailCode = '';
-      if (await this.hasLinkedWallets(session.wallets.length)) {
-        await this.navigateToReturnUrl();
-        return;
-      }
-
-      this.step = 'wallet';
-      this.info = 'Choose how you want to secure your wallet access.';
+      await this.navigateAfterAuth(session.wallets.length);
     } catch (error) {
       this.error =
         error instanceof Error ? error.message : 'Verification failed';
@@ -152,13 +141,7 @@ export class RegisterComponent {
     this.loading = true;
     try {
       const session = await this.authSession.login(method);
-      if (await this.hasLinkedWallets(session.wallets.length)) {
-        await this.navigateToReturnUrl();
-        return;
-      }
-
-      this.step = 'wallet';
-      this.info = 'Choose how you want to secure your wallet access.';
+      await this.navigateAfterAuth(session.wallets.length);
     } catch (error) {
       this.error =
         error instanceof Error ? error.message : 'Registration failed';
@@ -167,80 +150,22 @@ export class RegisterComponent {
     }
   }
 
-  public connectExistingWallet(): void {
-    this.error = '';
-    this.info = '';
-    this.isOpenWalletConnectMenu = true;
-    this.walletsService.requestOpen();
-  }
-
-  public closeWalletConnectMenu(): void {
-    this.isOpenWalletConnectMenu = false;
-  }
-
-  public async generateWallet(): Promise<void> {
-    this.error = '';
-    this.info = '';
-    this.walletLoading = true;
-
-    try {
-      await this.walletGatewayBridge.createEmbeddedWallet();
-      const wallets = await this.authSession.reloadWallets();
-      if (wallets.length === 0) {
-        throw new Error(
-          'Wallet was created but profile refresh returned no wallets.'
-        );
-      }
-      await this.navigateToReturnUrl();
-    } catch (error) {
-      this.error =
-        error instanceof Error ? error.message : 'Wallet setup failed';
-    } finally {
-      this.walletLoading = false;
-    }
-  }
-
-  public async finishAfterWalletLinked(): Promise<void> {
-    this.error = '';
-    this.info = '';
-    this.walletLoading = true;
-
-    try {
-      const wallets = await this.authSession.reloadWallets();
-      if (wallets.length === 0) {
-        this.error = 'Connect or generate a wallet to continue.';
-        return;
-      }
-      await this.navigateToReturnUrl();
-    } catch (error) {
-      this.error =
-        error instanceof Error ? error.message : 'Wallet refresh failed';
-    } finally {
-      this.walletLoading = false;
-    }
-  }
-
   private isEmail(value: string): boolean {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
   }
 
-  private async hasLinkedWallets(initialCount: number): Promise<boolean> {
-    if (initialCount > 0) {
-      return true;
+  private async navigateAfterAuth(initialWalletCount: number): Promise<void> {
+    if (await hasLinkedWallets(this.authSession, initialWalletCount)) {
+      await this.router.navigateByUrl(
+        readReturnUrl(this.route.snapshot.queryParamMap)
+      );
+      return;
     }
 
-    const wallets = await this.authSession.reloadWallets();
-    return wallets.length > 0;
-  }
-
-  private navigateToReturnUrl(): Promise<boolean> {
-    return this.router.navigateByUrl(this.returnUrl());
-  }
-
-  private returnUrl(): string {
-    const value = this.route.snapshot.queryParamMap.get('returnUrl');
-    return value && value.startsWith('/') && !value.startsWith('//')
-      ? value
-      : '/';
+    await this.router.navigate(['/generate-wallet'], {
+      queryParams: {
+        returnUrl: readReturnUrl(this.route.snapshot.queryParamMap),
+      },
+    });
   }
 }

--- a/src/app/pages/auth/shared/auth-login-messages.helper.spec.ts
+++ b/src/app/pages/auth/shared/auth-login-messages.helper.spec.ts
@@ -1,0 +1,61 @@
+import {
+  isPasskeyLoginUnavailableError,
+  isPasskeySetupRequiredError,
+  PASSKEY_LOGIN_UNAVAILABLE_MESSAGE,
+  PASSKEY_SETUP_REQUIRED_MESSAGE,
+  resolveLoginError,
+} from './auth-login-messages.helper';
+
+describe('auth-login-messages.helper', () => {
+  it('detects passkey setup errors', () => {
+    expect(
+      isPasskeySetupRequiredError('No passkey credentials found')
+    ).toBeTrue();
+    expect(isPasskeySetupRequiredError('Login failed')).toBeFalse();
+  });
+
+  it('does not treat provider capability errors as account setup errors', () => {
+    expect(
+      isPasskeyLoginUnavailableError('Passkey login is not enabled.')
+    ).toBeTrue();
+    expect(
+      isPasskeySetupRequiredError('Passkey login is not enabled.')
+    ).toBeFalse();
+  });
+
+  it('maps passkey setup errors to a profile-first message', () => {
+    expect(
+      resolveLoginError('passkey', new Error('Passkey not enabled for user'))
+    ).toBe(PASSKEY_SETUP_REQUIRED_MESSAGE);
+  });
+
+  it('maps passkey login capability errors to an availability message', () => {
+    expect(
+      resolveLoginError('passkey', new Error('Passkey login is not enabled.'))
+    ).toBe(PASSKEY_LOGIN_UNAVAILABLE_MESSAGE);
+    expect(
+      resolveLoginError('passkey', new Error('Login failed'), {
+        reasonCode: 'passkey_login_is_not_enabled',
+      })
+    ).toBe(PASSKEY_LOGIN_UNAVAILABLE_MESSAGE);
+  });
+
+  it('keeps generic login errors unchanged', () => {
+    expect(resolveLoginError('google', new Error('Provider unavailable'))).toBe(
+      'Provider unavailable'
+    );
+  });
+
+  it('falls back when the caught value is not an Error', () => {
+    expect(resolveLoginError('passkey', 'string error')).toBe('Login failed');
+    expect(resolveLoginError('google', { code: 'auth_failed' })).toBe(
+      'Login failed'
+    );
+  });
+
+  it('keeps unrelated passkey provider errors unchanged', () => {
+    expect(
+      resolveLoginError('passkey', new Error('Provider unavailable'))
+    ).toBe('Provider unavailable');
+  });
+});

--- a/src/app/pages/auth/shared/auth-login-messages.helper.ts
+++ b/src/app/pages/auth/shared/auth-login-messages.helper.ts
@@ -1,0 +1,61 @@
+import type { LoginMethod } from '@core/auth/auth-session.types';
+
+const PASSKEY_LOGIN_UNAVAILABLE_PATTERNS = [/passkey login is not enabled/i];
+
+const PASSKEY_ACCOUNT_NOT_SETUP_PATTERNS = [
+  /passkey.*not.*enabled.*(?:for|on).*user/i,
+  /passkey.*not.*linked/i,
+  /passkey.*not.*found/i,
+  /passkey.*not.*registered/i,
+  /passkey.*not.*set/i,
+  /no passkey/i,
+  /no.*passkey.*credential/i,
+  /credential.*not.*found/i,
+];
+
+export const PASSKEY_SETUP_REQUIRED_MESSAGE =
+  'Passkey sign-in is not set up on your account yet. Sign in with Google, Apple, or Telegram first, then enable passkey in your profile.';
+
+export const PASSKEY_LOGIN_UNAVAILABLE_MESSAGE =
+  'Passkey sign-in is not available right now. Please use Google, Apple, Telegram, or email to sign in.';
+
+export function isPasskeyLoginUnavailableError(message: string): boolean {
+  return PASSKEY_LOGIN_UNAVAILABLE_PATTERNS.some(pattern =>
+    pattern.test(message)
+  );
+}
+
+export function isPasskeySetupRequiredError(message: string): boolean {
+  if (isPasskeyLoginUnavailableError(message)) {
+    return false;
+  }
+
+  return PASSKEY_ACCOUNT_NOT_SETUP_PATTERNS.some(pattern =>
+    pattern.test(message)
+  );
+}
+
+export function resolveLoginError(
+  method: LoginMethod,
+  error: unknown,
+  options?: { reasonCode?: string }
+): string {
+  const message = error instanceof Error ? error.message : 'Login failed';
+
+  if (method !== 'passkey') {
+    return message;
+  }
+
+  if (
+    options?.reasonCode === 'passkey_login_is_not_enabled' ||
+    isPasskeyLoginUnavailableError(message)
+  ) {
+    return PASSKEY_LOGIN_UNAVAILABLE_MESSAGE;
+  }
+
+  if (isPasskeySetupRequiredError(message)) {
+    return PASSKEY_SETUP_REQUIRED_MESSAGE;
+  }
+
+  return message;
+}

--- a/src/app/pages/auth/shared/auth-navigation.helper.ts
+++ b/src/app/pages/auth/shared/auth-navigation.helper.ts
@@ -1,0 +1,24 @@
+import { ParamMap } from '@angular/router';
+import { AuthSessionService } from '@core/auth/auth-session.service';
+
+export function safeReturnUrl(value: string | null | undefined): string {
+  return value && value.startsWith('/') && !value.startsWith('//')
+    ? value
+    : '/';
+}
+
+export function readReturnUrl(queryParamMap: ParamMap): string {
+  return safeReturnUrl(queryParamMap.get('returnUrl'));
+}
+
+export async function hasLinkedWallets(
+  authSession: AuthSessionService,
+  initialCount: number
+): Promise<boolean> {
+  if (initialCount > 0) {
+    return true;
+  }
+
+  const wallets = await authSession.reloadWallets();
+  return wallets.length > 0;
+}

--- a/src/app/pages/auth/shared/auth-social-buttons.component.html
+++ b/src/app/pages/auth/shared/auth-social-buttons.component.html
@@ -3,7 +3,7 @@
     *ngIf="isEnabled('passkey')"
     class="register-shell__social register-shell__social--passkey"
     type="button"
-    [disabled]="disabled"
+    [disabled]="isMethodDisabled('passkey')"
     (click)="select('passkey')">
     <span class="register-shell__social-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" focusable="false">
@@ -22,7 +22,7 @@
     *ngIf="isEnabled('google')"
     class="register-shell__social register-shell__social--google"
     type="button"
-    [disabled]="disabled"
+    [disabled]="isMethodDisabled('google')"
     (click)="select('google')">
     <span class="register-shell__social-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" focusable="false">
@@ -47,7 +47,7 @@
     *ngIf="isEnabled('apple')"
     class="register-shell__social register-shell__social--apple"
     type="button"
-    [disabled]="disabled"
+    [disabled]="isMethodDisabled('apple')"
     (click)="select('apple')">
     <span class="register-shell__social-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" focusable="false">
@@ -63,7 +63,7 @@
     *ngIf="isEnabled('telegram')"
     class="register-shell__social register-shell__social--telegram"
     type="button"
-    [disabled]="disabled"
+    [disabled]="isMethodDisabled('telegram')"
     (click)="select('telegram')">
     <span class="register-shell__social-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" focusable="false">

--- a/src/app/pages/auth/shared/auth-social-buttons.component.ts
+++ b/src/app/pages/auth/shared/auth-social-buttons.component.ts
@@ -10,6 +10,7 @@ export type AuthSocialMethod = 'passkey' | 'google' | 'apple' | 'telegram';
 export class AuthSocialButtonsComponent {
   @Input() public disabled = false;
   @Input() public methods: AuthSocialMethod[] = ['google', 'apple'];
+  @Input() public disabledMethods: AuthSocialMethod[] = [];
 
   @Output() public methodSelected = new EventEmitter<AuthSocialMethod>();
 
@@ -17,7 +18,15 @@ export class AuthSocialButtonsComponent {
     return this.methods.includes(method);
   }
 
+  public isMethodDisabled(method: AuthSocialMethod): boolean {
+    return this.disabled || this.disabledMethods.includes(method);
+  }
+
   public select(method: AuthSocialMethod): void {
+    if (this.isMethodDisabled(method)) {
+      return;
+    }
+
     this.methodSelected.emit(method);
   }
 }

--- a/src/app/pages/home/home-routing.module.ts
+++ b/src/app/pages/home/home-routing.module.ts
@@ -1,11 +1,13 @@
 import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './home.component';
 import { NgModule } from '@angular/core';
+import { AuthGuard } from '@core/auth/auth.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: HomeComponent,
+    canActivate: [AuthGuard],
   },
 ];
 

--- a/src/index.html
+++ b/src/index.html
@@ -15,20 +15,6 @@
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet" />
-    <style>
-      html.auth-shell-route app-header,
-      html.auth-shell-route app-sidebar {
-        display: none !important;
-      }
-    </style>
-    <script>
-      (function () {
-        var path = window.location.pathname;
-        if (path.indexOf('/login') === 0 || path.indexOf('/register') === 0) {
-          document.documentElement.classList.add('auth-shell-route');
-        }
-      })();
-    </script>
   </head>
   <body>
     <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -80,6 +80,7 @@ a {
 
 @import './styles/exchange-page';
 @import './styles/register-page';
+@import './styles/profile-page';
 
 .swap-form {
   --swap-radius: 10px;

--- a/src/styles/profile-page.scss
+++ b/src/styles/profile-page.scss
@@ -1,0 +1,281 @@
+.profile-shell {
+  display: grid;
+  padding: clamp(1rem, 3vw, 2rem);
+  gap: 1rem;
+
+  &__header {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    h1 {
+      margin: 0.25rem 0 0;
+      font-size: 1.35rem;
+      font-weight: 600;
+      line-height: 1.25;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__header-actions {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__eyebrow {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
+  &__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  &__panel {
+    min-width: 0;
+    padding: 1rem;
+    border: 1px solid rgb(255 255 255 / 14%);
+    border-radius: 8px;
+    background: rgb(255 255 255 / 3%);
+
+    h2 {
+      margin: 0 0 1rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+
+    &--wide {
+      grid-column: 1 / -1;
+    }
+  }
+
+  &__panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+
+    h2 {
+      margin-bottom: 0;
+    }
+  }
+
+  &__wallet-connect {
+    margin: 0 0 1rem;
+  }
+
+  dl {
+    display: grid;
+    margin: 0;
+    gap: 0.85rem;
+
+    div {
+      display: grid;
+      min-width: 0;
+      gap: 0.2rem;
+    }
+  }
+
+  dt,
+  small {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1.1rem;
+  }
+
+  dd {
+    margin: 0;
+    color: var(--gray-30);
+    font-size: 0.92rem;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+  }
+
+  &__wallets {
+    display: grid;
+    padding: 0;
+    margin: 0;
+    gap: 0.65rem;
+    list-style: none;
+
+    li {
+      display: flex;
+      min-width: 0;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+  }
+
+  &__wallet-main {
+    display: grid;
+    min-width: 0;
+    gap: 0.15rem;
+  }
+
+  &__wallet-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+  }
+
+  &__balances {
+    display: grid;
+    padding: 0;
+    margin: 0;
+    gap: 0.65rem;
+    list-style: none;
+
+    li {
+      display: grid;
+      min-width: 0;
+      align-items: center;
+      padding: 0.7rem 0;
+      border-top: 1px solid rgb(255 255 255 / 10%);
+      gap: 1rem;
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+
+      &:first-child {
+        border-top: 0;
+      }
+    }
+  }
+
+  &__balance-asset,
+  &__balance-value {
+    display: grid;
+    min-width: 0;
+    gap: 0.15rem;
+
+    span,
+    small {
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__balance-value {
+    justify-items: end;
+    text-align: right;
+
+    span {
+      color: var(--gray-30);
+      font-weight: 600;
+    }
+  }
+
+  &__primary {
+    color: var(--success, #7ee787);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
+  &__passkey-icon {
+    display: inline-flex;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgb(255 255 255 / 14%);
+    border-radius: 999px;
+    background: rgb(255 255 255 / 4%);
+
+    svg {
+      display: block;
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  }
+
+  &__passkey-copy {
+    display: grid;
+    min-width: 0;
+    gap: 0.35rem;
+  }
+
+  &__passkey-label {
+    font-size: 0.92rem;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  &__passkey-status {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+
+    --passkey-tone: var(--primary-text-color);
+    --passkey-bg: rgb(254 108 0 / 12%);
+    --passkey-border: rgb(254 108 0 / 28%);
+
+    &--enabled {
+      --passkey-tone: var(--success, #7ee787);
+      --passkey-bg: rgb(126 231 135 / 12%);
+      --passkey-border: rgb(126 231 135 / 28%);
+    }
+
+    .profile-shell__passkey-icon {
+      border-color: var(--passkey-border);
+      background: var(--passkey-bg);
+      color: var(--passkey-tone);
+    }
+
+    .profile-shell__passkey-label {
+      color: var(--passkey-tone);
+    }
+  }
+
+  &__empty,
+  &__message,
+  &__error {
+    color: var(--gray-30);
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+
+  &__error {
+    color: #ffb085;
+  }
+}
+
+@media (width <= 720px) {
+  .profile-shell {
+    &__header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    &__grid {
+      grid-template-columns: 1fr;
+    }
+
+    &__wallets li {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.15rem;
+    }
+
+    &__wallet-actions {
+      justify-content: flex-start;
+    }
+
+    &__balances li {
+      gap: 0.35rem;
+      grid-template-columns: 1fr;
+    }
+
+    &__balance-value {
+      justify-items: start;
+      text-align: left;
+    }
+  }
+}


### PR DESCRIPTION
* feat(auth): align login flow, wallet onboarding, and session redirects

Route unauthenticated users to /login, extract first-time wallet setup to /generate-wallet, and always show passkey/social options on login with a profile-first error when passkey is not enabled. Centralize auth-shell routes in layout and remove the redundant index.html pre-bootstrap hack.

* fix(auth): distinguish passkey linked from passkey login availability

Profile and login were treating linked passkeys as sign-in ready even when passkeyLoginEnabled is false. Show linked-only state in profile, disable passkey on login with an upfront note, and map provider capability errors separately from account-setup errors.

* fix(ci): extract profile styles to fix production component budget failure

* fix(auth): protect home route with AuthGuard after logout

Redirect unauthenticated users from `/` to `/login?returnUrl=/` so the exchange page is no longer reachable without a valid session.

* fix(auth): filter login social methods

* fix(ci): mock authenticated shell e2e session

---------