### PR TITLE
release: use auth provider for first wallet setup

### DIFF
--- a/e2e/utils/auth-fixtures.ts
+++ b/e2e/utils/auth-fixtures.ts
@@ -137,7 +137,7 @@ const modules = {
   'auth-provider': {
     mountAuthProvider: function () {
       return {
-        contractVersion: '2.2.0',
+        contractVersion: '2.3.0',
         unmount: function () {},
         subscribe: function (listener) {
           queueMicrotask(function () { listener(snapshot); });
@@ -148,6 +148,9 @@ const modules = {
         sendEmailCode: function () { return Promise.resolve(); },
         verifyEmailCode: function () { return Promise.resolve(session); },
         linkPasskey: function () { return Promise.resolve(session); },
+        ensureEmbeddedWallet: function () {
+          return Promise.resolve(session.wallets[0]);
+        },
         logout: function () { return Promise.resolve(); },
         getAccessToken: function () {
           return Promise.resolve(${serializedAccessToken});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const PORT = 5002;
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 5002);
 const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({
@@ -29,7 +29,7 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI
-      ? `pnpm run build && pnpm exec serve -s dist/cs_ng_app_client -l ${PORT}`
+      ? `pnpm exec ng build --configuration development && pnpm exec serve -s dist/cs_ng_app_client -l ${PORT}`
       : `pnpm run start`,
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,

--- a/src/app/core/auth/auth-provider.service.spec.ts
+++ b/src/app/core/auth/auth-provider.service.spec.ts
@@ -18,7 +18,7 @@ function mountApi(
   onSubscribe?: (listener: AuthProviderListener) => void
 ): AuthProviderMountApi {
   return {
-    contractVersion: '2.2.0',
+    contractVersion: '2.3.0',
     unmount: jasmine.createSpy('unmount'),
     subscribe: listener => {
       onSubscribe?.(listener);
@@ -51,6 +51,16 @@ function mountApi(
         passkeyEnabled: true,
       },
       wallets: [],
+    }),
+    ensureEmbeddedWallet: async () => ({
+      id: 'wallet-1',
+      providerWalletId: 'provider-wallet-1',
+      address: '0x1111111111111111111111111111111111111111',
+      chainType: 'ethereum',
+      walletType: 'embedded',
+      source: 'provider',
+      status: 'active',
+      isPrimary: true,
     }),
     getAccessToken: async () => 'provider-token',
     logout: async () => undefined,

--- a/src/app/core/auth/auth-provider.service.ts
+++ b/src/app/core/auth/auth-provider.service.ts
@@ -8,6 +8,7 @@ import {
   AuthProviderRemoteModule,
   AuthProviderSession,
   AuthProviderSnapshot,
+  AuthProviderWallet,
 } from '@mfe-contracts/auth-provider.types';
 import {
   WALLET_REMOTE_EXPOSED_MODULES,
@@ -87,6 +88,10 @@ export class AuthProviderService implements OnDestroy {
 
   linkPasskey(): Promise<AuthProviderSession> {
     return this.requireReadyProvider().linkPasskey();
+  }
+
+  ensureEmbeddedWallet(): Promise<AuthProviderWallet> {
+    return this.requireReadyProvider().ensureEmbeddedWallet();
   }
 
   logout(): Promise<void> {
@@ -276,6 +281,8 @@ export class AuthProviderService implements OnDestroy {
       typeof value.verifyEmailCode === 'function' &&
       'linkPasskey' in value &&
       typeof value.linkPasskey === 'function' &&
+      'ensureEmbeddedWallet' in value &&
+      typeof value.ensureEmbeddedWallet === 'function' &&
       'logout' in value &&
       typeof value.logout === 'function' &&
       'getAccessToken' in value &&

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -179,6 +179,15 @@ export class AuthSessionService {
     }
   }
 
+  async ensureEmbeddedWallet(): Promise<void> {
+    this.loadingSubject.next(true);
+    try {
+      await this.authProvider.ensureEmbeddedWallet();
+    } finally {
+      this.loadingSubject.next(false);
+    }
+  }
+
   async logout(): Promise<void> {
     this.loadingSubject.next(true);
     try {

--- a/src/app/mfe-contracts/README.md
+++ b/src/app/mfe-contracts/README.md
@@ -20,7 +20,7 @@ Use this as the source of truth for runtime communication in the Angular app.
 The canonical, open runtime contract is
 `cs_mfe-wallets/src/contracts/auth-provider-contract.ts`. This host keeps only
 the structural consumer copy in `auth-provider.types.ts` and validates contract
-version `2.2.0` before mounting `mfe-wallets/auth-provider`.
+version `2.3.0` before mounting `mfe-wallets/auth-provider`.
 
 The wallet remote exposes atomized entrypoints:
 

--- a/src/app/mfe-contracts/auth-provider.types.ts
+++ b/src/app/mfe-contracts/auth-provider.types.ts
@@ -5,10 +5,10 @@
  * The wallet MFE is the single source of truth. Keep this copy compatible and
  * reject unsupported contract versions at runtime.
  */
-export type AuthProviderContractVersion = '2.2.0';
+export type AuthProviderContractVersion = '2.3.0';
 
 export const AUTH_PROVIDER_CONTRACT_VERSION: AuthProviderContractVersion =
-  '2.2.0';
+  '2.3.0';
 
 export type AuthProviderLoginMethod = 'email' | 'google' | 'apple' | 'passkey';
 
@@ -68,6 +68,7 @@ export type AuthProviderMountApi = {
     input: AuthProviderEmailCodeInput
   ) => Promise<AuthProviderSession>;
   linkPasskey: () => Promise<AuthProviderSession>;
+  ensureEmbeddedWallet: () => Promise<AuthProviderWallet>;
   logout: () => Promise<void>;
   getAccessToken: () => Promise<string | null>;
 };

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.spec.ts
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.spec.ts
@@ -1,7 +1,5 @@
 import { convertToParamMap, ParamMap, Router } from '@angular/router';
 import { AuthSessionService } from '@core/auth/auth-session.service';
-import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
-import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import { of } from 'rxjs';
 import { GenerateWalletComponent } from './generate-wallet.component';
 
@@ -9,14 +7,12 @@ describe('GenerateWalletComponent', () => {
   let component: GenerateWalletComponent;
   let authSession: jasmine.SpyObj<AuthSessionService>;
   let router: jasmine.SpyObj<Router>;
-  let walletsService: jasmine.SpyObj<WalletsService>;
-  let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
   let queryParamMap: ParamMap;
 
   beforeEach(() => {
     authSession = jasmine.createSpyObj<AuthSessionService>(
       'AuthSessionService',
-      ['reloadWallets'],
+      ['ensureEmbeddedWallet', 'reloadWallets'],
       {
         session: {
           user: {
@@ -37,42 +33,27 @@ describe('GenerateWalletComponent', () => {
       }
     );
     router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
-    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
-      'requestOpen',
-    ]);
-    walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
-      'WalletGatewayBridgeService',
-      ['createEmbeddedWallet']
-    );
     queryParamMap = convertToParamMap({});
     router.navigateByUrl.and.resolveTo(true);
+    authSession.ensureEmbeddedWallet.and.resolveTo();
     authSession.reloadWallets.and.resolveTo([]);
 
     component = new GenerateWalletComponent(
       authSession,
       router,
-      { snapshot: { queryParamMap } } as never,
-      walletsService,
-      walletGatewayBridge
+      { snapshot: { queryParamMap } } as never
     );
   });
 
-  it('opens the wallet connector from the page', () => {
+  it('opens only the page-owned wallet connector modal', () => {
     component.connectExistingWallet();
 
     expect(component.isOpenWalletConnectMenu).toBeTrue();
-    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
   });
 
   it('generates an embedded wallet and navigates after backend wallet refresh', async () => {
     queryParamMap = convertToParamMap({ returnUrl: '//evil.example' });
     component = createComponent();
-    walletGatewayBridge.createEmbeddedWallet.and.resolveTo({
-      account: '0x1111111111111111111111111111111111111111',
-      chainId: 1,
-      walletType: 'embedded',
-      source: 'provider',
-    });
     authSession.reloadWallets.and.resolveTo([
       {
         id: 'wallet-1',
@@ -86,7 +67,7 @@ describe('GenerateWalletComponent', () => {
 
     await component.generateWallet();
 
-    expect(walletGatewayBridge.createEmbeddedWallet).toHaveBeenCalledTimes(1);
+    expect(authSession.ensureEmbeddedWallet).toHaveBeenCalledTimes(1);
     expect(authSession.reloadWallets).toHaveBeenCalledTimes(1);
     expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/');
   });
@@ -121,9 +102,7 @@ describe('GenerateWalletComponent', () => {
     return new GenerateWalletComponent(
       authSession,
       router,
-      { snapshot: { queryParamMap } } as never,
-      walletsService,
-      walletGatewayBridge
+      { snapshot: { queryParamMap } } as never
     );
   }
 });

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.ts
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthSessionService } from '@core/auth/auth-session.service';
-import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
-import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import { authPageTransition } from '../shared/auth-page.animations';
 import {
   hasLinkedWallets,
@@ -25,9 +23,7 @@ export class GenerateWalletComponent implements OnInit {
   constructor(
     public readonly authSession: AuthSessionService,
     private readonly router: Router,
-    private readonly route: ActivatedRoute,
-    private readonly walletsService: WalletsService,
-    private readonly walletGatewayBridge: WalletGatewayBridgeService
+    private readonly route: ActivatedRoute
   ) {}
 
   public async ngOnInit(): Promise<void> {
@@ -47,7 +43,6 @@ export class GenerateWalletComponent implements OnInit {
     this.error = '';
     this.info = '';
     this.isOpenWalletConnectMenu = true;
-    this.walletsService.requestOpen();
   }
 
   public closeWalletConnectMenu(): void {
@@ -60,7 +55,7 @@ export class GenerateWalletComponent implements OnInit {
     this.walletLoading = true;
 
     try {
-      await this.walletGatewayBridge.createEmbeddedWallet();
+      await this.authSession.ensureEmbeddedWallet();
       const wallets = await this.authSession.reloadWallets();
       if (wallets.length === 0) {
         throw new Error(


### PR DESCRIPTION
## Summary
- consume auth-provider contract 2.3.0 and expose ensureEmbeddedWallet in the host
- make /generate-wallet use the active auth-provider session instead of the wallet gateway passkey connector
- stop broadcasting requestOpen from the page-owned existing-wallet modal to avoid duplicate MFE dialogs

## Tests
- pnpm exec ng build --configuration development

## Notes
- Focused Karma specs could not complete in this container: default Chrome cannot run as root, and ChromeHeadlessNoSandbox connected but timed out before specs completed.