### PR TITLE
release: promote view wallet flow to production

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -40,14 +40,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure registry for @vodis (GitHub Packages)
-        run: |
-          echo "@vodis:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+          registry-url: https://npm.pkg.github.com
+          scope: '@vodis'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: TypeScript / ESLint
         run: pnpm run lint
@@ -70,14 +69,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure registry for @vodis (GitHub Packages)
-        run: |
-          echo "@vodis:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+          registry-url: https://npm.pkg.github.com
+          scope: '@vodis'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Install Chromium for headless tests
         run: |
@@ -107,14 +105,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure registry for @vodis (GitHub Packages)
-        run: |
-          echo "@vodis:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+          registry-url: https://npm.pkg.github.com
+          scope: '@vodis'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Install Playwright Chromium
         run: pnpm run e2e:install
@@ -142,14 +139,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure registry for @vodis (GitHub Packages)
-        run: |
-          echo "@vodis:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+          registry-url: https://npm.pkg.github.com
+          scope: '@vodis'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Production build (verify only, no deploy)
         run: pnpm run build-prod

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -41,18 +41,13 @@ jobs:
         with:
           node-version: '22'
           cache: pnpm
-
-      - name: npm auth (@vodis packages)
-        run: |
-          if [ -z "${{ secrets.GH_PACKAGES_TOKEN }}" ]; then
-            echo "::error::Add repository secret GH_PACKAGES_TOKEN with read:packages access."
-            exit 1
-          fi
-          echo "@vodis:registry=https://npm.pkg.github.com/" >> .npmrc
-          printf '//npm.pkg.github.com/:_authToken=%s\n' "${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+          registry-url: https://npm.pkg.github.com
+          scope: '@vodis'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Build production bundle
         run: pnpm run build-prod

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -20,6 +20,20 @@ This guide is for AI/code agents and contributors working in `cs_ng_app_client`.
 - Integrate `mfe-wallets` safely through Module Federation.
 - Build a robust Angular dApp shell with predictable contracts.
 
+## UI Branding Reference
+
+When working on UI interface, visual styling, layout, spacing, typography,
+responsive behavior, shell chrome, or any user-facing design detail, use
+`BRANDING_BOOK.md` as the primary reference.
+
+Use it for:
+
+- palette and token decisions
+- font and typography sizing
+- spacing, padding, and shell measurements
+- mobile, laptop, and desktop dimension guidance
+- preserving visual consistency across header, sidebar, pages, and panels
+
 ## Exchange Page UI Reference
 
 The default route (`/`) renders the **Token Exchange** screen inside the host shell. Treat the layout below as the product baseline when changing home-page UI or styles.

--- a/BRANDING_BOOK.md
+++ b/BRANDING_BOOK.md
@@ -1,0 +1,195 @@
+# CraftScript Branding Book
+
+This file is a quick visual reference for the app shell and dashboard UI.
+
+## Palette
+
+Core brand colors:
+
+- `--main-bg-color`: `#171c1f` - main app background
+- `--main-border-color`: `#d4d4d3` - dividers, shell lines, borders
+- `--main-text-color`: `#ffffff` - primary text on dark surfaces
+- `--primary-text-color`: `#fe6c00` - accent orange, CTA, active states
+- `--secondary-text-color`: `#767676` - muted labels and supporting text
+- `--gray-30`: `#cfcbd2` - decorative gray copy
+- `--gray-100`: `#080708` - dark text on light contexts
+
+Material token overrides:
+
+- Primary: orange `#fe6c00`
+- Secondary: gray `#767676`
+- On primary: white `#ffffff`
+
+## Font Stack
+
+Primary app sans stack:
+
+```css
+ui-sans-serif, system-ui, -apple-system, 'system-ui', 'Segoe UI', Roboto,
+'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'
+```
+
+Project-specific fonts:
+
+- `Aeonik Fono` - numeric and monospace-like accent usage
+- `GTF Adieu TRIAL` - bundled, but current display headings use `KodeMono, sans-serif`
+
+## Typography Sizes
+
+Base sizing:
+
+- Root/base size: `16px`
+- Body default: `1.6rem` (`25.6px`)
+- Mobile body: `1.4rem` (`22.4px`)
+
+Heading scale:
+
+- `h1` / `.h1`: `5rem`, mobile `3rem`, `700`, uppercase
+- `h2` / `.h2`: `3.6rem`, mobile `2.8rem`, `700`, lowercase
+- `h3` / `.h3`: `2.5rem`, mobile `1.8rem`, `400`, lowercase
+- `h4` / `.h4`, `h5`, `h6`: `1.8rem`, `400`
+
+Utility text:
+
+- `.subtitle`: `1.2rem`, uppercase
+- `.body-1`: `1.6rem`, mobile `1.4rem`
+- `.caption`: `max(1rem, 11px)`, uppercase
+
+Number styles:
+
+- `.number-1`: `4.8rem`, mobile `3.8rem`
+- `.number-2`: `2.5rem`, mobile `2rem`
+- `.number-3`: `1.8rem`, mobile `2rem`
+
+## Spacing And Padding
+
+Grid margins by breakpoint:
+
+- `xs`: `1rem` (`16px`)
+- `sm`: `1.6rem` (`25.6px`)
+- `md`: `2.4rem` (`38.4px`)
+- `lg`: `3rem` (`48px`)
+- `xl`: `4rem` (`64px`)
+- `2xl`: `4rem` (`64px`)
+
+Grid gutters by breakpoint:
+
+- `xs`: `0.9rem` (`14.4px`)
+- `sm`: `1.2rem` (`19.2px`)
+- `md`: `1.2rem` (`19.2px`)
+- `lg`: `1.2rem` (`19.2px`)
+- `xl`: `1.6rem` (`25.6px`)
+- `2xl`: `1.6rem` (`25.6px`)
+
+Common shell measurements:
+
+- Header height: `4rem` (`64px`)
+- Mobile bottom nav height: `4rem` (`64px`)
+- Scrollable shell area: `calc(100vh - 4rem)`
+
+## Mobile Measurements
+
+Mobile app shell applies below `768px`.
+
+- Mobile breakpoint: `< 768px`
+- Shell grid columns: `4`
+- Header height: `64px`
+- Bottom navigation height: `64px`
+- Typical horizontal shell margin: `16px` on `xs`, `25.6px` on `sm`
+
+Recommended reference widths:
+
+- Small mobile: `320px`
+- Standard mobile: `360px`
+- Large mobile: `390px`
+- Mobile max before tablet/desktop shell change: `767px`
+
+## Laptop Dimensions
+
+Useful laptop range in this project:
+
+- `lg`: `976px` and up
+- Laptop working range: `976px - 1439px`
+
+Recommended laptop reference widths:
+
+- Small laptop: `1024px`
+- Standard laptop: `1280px`
+- Large laptop: `1366px`
+
+Shell behavior:
+
+- Desktop shell is already active from `768px+`
+- At laptop widths, the app still uses the `7`-column shell
+- Main content spans columns `2-7`
+- Sidebar stays in column `1`
+
+## Desktop Dimensions
+
+Large desktop breakpoint:
+
+- `xl`: `1440px`
+- `2xl`: `1536px`
+
+Recommended desktop reference widths:
+
+- Desktop baseline: `1440px`
+- Large desktop: `1536px`
+- Wide desktop: `1728px` or `1920px`
+
+Typography behavior on large desktop:
+
+- Up to `1440px`, root size stays at `16px`
+- In the `xl` band, root size scales fluidly with viewport width
+
+## Layout Structure
+
+Shell layout is one of the most important parts of this branding book. The app
+frame, header, sidebar, divider, and routed content must stay aligned to the
+same shell grid. This is not just a visual preference: the shell layout is
+protected by E2E tests and should be treated as a contract.
+
+Shell grid:
+
+- Mobile: `4` columns
+- Desktop and up: `7` columns
+
+Desktop placement:
+
+- Logo: column `1`
+- Sidebar: column `1`
+- Divider: end of column `1`
+- Main content: columns `2-7`
+
+Rules:
+
+- Full viewport width
+- No max-width page container
+- Use `--main-border-color` for shell lines
+- Keep shell chrome aligned across header, sidebar, and content
+
+Protected shell layout requirements:
+
+- Header height must remain `64px`
+- Main content must start directly below the header
+- Sidebar width must match the first column of the `7`-column desktop grid
+- Vertical divider must stay aligned with the sidebar right edge
+- Sidebar, divider, and router content must share the same grid row
+
+E2E coverage:
+
+- Shell layout regression tests live in `e2e/shell-layout.spec.ts`
+- When changing shell UI, header, sidebar, divider, or responsive grid
+  behavior, preserve those expectations and run the shell layout E2E tests
+
+## Source Of Truth
+
+Main files:
+
+- `src/assets/styles/default-theme-colors.css`
+- `src/styles.scss`
+- `@vodis/cs-foundation/styles/variables`
+- `@vodis/cs-foundation/styles/typography`
+- `src/app/components/layout/layout.component.scss`
+- `docs/design-system.md`

--- a/angular.json
+++ b/angular.json
@@ -43,7 +43,7 @@
             "extraWebpackConfig": "config/webpack.config.js",
             "commonChunk": false,
             "stylePreprocessorOptions": {
-              "includePaths": ["../node_modules/src/app/styles"]
+              "includePaths": ["src"]
             }
           },
           "configurations": {
@@ -118,7 +118,10 @@
               "src/assets/styles/default-theme-colors.css",
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "stylePreprocessorOptions": {
+              "includePaths": ["src"]
+            }
           }
         },
         "lint": {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -4,7 +4,7 @@ const {
 } = require('@angular-architects/module-federation/webpack');
 const mfManifest = require('../src/config/mf.manifest.json');
 
-module.exports = withModuleFederationPlugin({
+const mfConfig = withModuleFederationPlugin({
   remotes: mfManifest,
 
   shared: {
@@ -15,3 +15,13 @@ module.exports = withModuleFederationPlugin({
     }),
   },
 });
+
+// Override MF `publicPath: 'auto'` — avoids import.meta in styles.js (Angular classic script).
+module.exports = {
+  ...mfConfig,
+  output: {
+    ...mfConfig.output,
+    uniqueName: 'cs_ng_app_client',
+    publicPath: '/',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/router": "^19.2.0",
     "@babel/runtime": "^7.28.6",
     "@hakimio/ngx-google-analytics": "^15.0.0",
-    "@vodis/ui-kit": "^1.0.15",
+    "@vodis/cs-foundation": "0.2.0",
     "liveline": "^0.0.7",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,9 @@ importers:
       '@hakimio/ngx-google-analytics':
         specifier: ^15.0.0
         version: 15.0.0(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(@angular/router@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(rxjs@7.8.2)
-      '@vodis/ui-kit':
-        specifier: ^1.0.15
-        version: 1.0.15
+      '@vodis/cs-foundation':
+        specifier: 0.2.0
+        version: 0.2.0
       liveline:
         specifier: ^0.0.7
         version: 0.0.7(react@19.2.7)
@@ -2610,6 +2610,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-basic-ssl@1.2.0':
     resolution: {integrity: sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==}
@@ -2617,8 +2618,8 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@vodis/ui-kit@1.0.15':
-    resolution: {integrity: sha512-LcT2lUkt8DRfhuQyY+g/PVS91YxSafkTSY6i8cC/vaUAewMxvJyupUg9fbjSar6U3Pq+sAb9YeCO36uXCIwX6g==, tarball: https://npm.pkg.github.com/download/@vodis/ui-kit/1.0.15/65a5edc7677fd97204c1e499787bf0dd7062eea9}
+  '@vodis/cs-foundation@0.2.0':
+    resolution: {integrity: sha512-nwfVo3iD8VtUwDVz+QBhl5+BHBstAf/CyfDpAfS4K6NtB0cN00dQuXmbu5AihU7jhrsZXMMxeY85tgc4dzZAOQ==, tarball: https://npm.pkg.github.com/download/@vodis/cs-foundation/0.2.0/63686487607882b6031f953f02a93c97488c5fbe}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -3340,6 +3341,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -6558,6 +6560,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -9490,7 +9493,7 @@ snapshots:
     dependencies:
       vite: 6.4.1(@types/node@20.19.37)(jiti@1.21.7)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.8.2)
 
-  '@vodis/ui-kit@1.0.15': {}
+  '@vodis/cs-foundation@0.2.0': {}
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,5 +1,3 @@
-@import '@vodis/ui-kit/styles/breakpoints';
-
 :host {
   display: block;
   height: var(--shell-header-height);
@@ -39,8 +37,8 @@
       height: 100%;
       align-items: center;
       justify-content: flex-end;
-      gap: 0.75rem;
       padding-right: 1.5rem;
+      gap: 0.75rem;
       grid-column: 2 / 8;
     }
 

--- a/src/app/components/layout/layout.component.scss
+++ b/src/app/components/layout/layout.component.scss
@@ -1,5 +1,3 @@
-@import '@vodis/ui-kit/styles/breakpoints';
-
 :host {
   .main-layout {
     min-height: 100vh;
@@ -62,9 +60,9 @@
         flex-direction: column;
 
         > .main-layout__content_mobile {
-          flex: 0 1 auto;
           width: 100%;
           min-width: 0;
+          flex: 0 1 auto;
           overflow-x: hidden;
         }
 

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -1,4 +1,4 @@
-@import '@vodis/ui-kit/styles/breakpoints';
+@use '@vodis/cs-foundation/styles/breakpoints' as *;
 
 :host {
   .mat-expansion-panel:not([class*='mat-elevation-z']) {

--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -31,6 +31,7 @@ describe('AuthSessionService', () => {
         'linkPasskey',
         'logout',
         'getAccessToken',
+        'ensureEmbeddedWallet',
       ],
       {
         snapshot: {
@@ -77,10 +78,27 @@ describe('AuthSessionService', () => {
       wallets: [],
     });
     authProvider.logout.and.resolveTo();
+    authProvider.ensureEmbeddedWallet.and.resolveTo({
+      id: 'wallet-1',
+      providerWalletId: 'provider-wallet-1',
+      address: '0x1111111111111111111111111111111111111111',
+      chainType: 'ethereum',
+      walletType: 'embedded',
+      isPrimary: true,
+    });
     walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
       'WalletGatewayBridgeService',
-      ['disconnectWallet']
+      ['disconnectWallet', 'syncConnectedWallet']
     );
+    walletGatewayBridge.syncConnectedWallet.and.resolveTo({
+      status: 'connected',
+      account: '0x1111111111111111111111111111111111111111',
+      chainId: null,
+      isVerified: false,
+      safetyStatus: null,
+      isBypassed: false,
+      executionState: 'operating.idle',
+    });
     walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
       'setAccount',
     ]);
@@ -205,6 +223,14 @@ describe('AuthSessionService', () => {
     expect(walletsService.setAccount).toHaveBeenCalledOnceWith(undefined);
     expect(service.session).toBeNull();
     expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/login');
+  }));
+
+  it('syncs the wallet gateway after ensuring an embedded wallet', fakeAsync(() => {
+    service.ensureEmbeddedWallet();
+    flushMicrotasks();
+
+    expect(authProvider.ensureEmbeddedWallet).toHaveBeenCalledTimes(1);
+    expect(walletGatewayBridge.syncConnectedWallet).toHaveBeenCalledTimes(1);
   }));
 
   it('refreshes session and wallets using the provider access token', fakeAsync(() => {

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -183,6 +183,9 @@ export class AuthSessionService {
     this.loadingSubject.next(true);
     try {
       await this.authProvider.ensureEmbeddedWallet();
+      await this.walletGatewayBridge
+        .syncConnectedWallet()
+        .catch(() => undefined);
     } finally {
       this.loadingSubject.next(false);
     }

--- a/src/app/mfe-contracts/README.md
+++ b/src/app/mfe-contracts/README.md
@@ -61,24 +61,24 @@ No direct imports from MFE internals into host domain logic.
 
 ### 1.2 Canonical event names
 
+- `connection.state.changed`
+- `connection.snapshot.updated`
 - `wallet.connected`
 - `wallet.disconnected`
-- `wallet.accountChanged`
-- `wallet.chainChanged`
-- `wallet.txSigned`
-- `wallet.error`
+- `wallet.account.changed`
+- `wallet.chain.changed`
 
 ### 1.3 Event payload envelope (required)
 
 ```ts
 export interface MfeEventEnvelope<TPayload = unknown> {
   eventName:
+    | 'connection.state.changed'
+    | 'connection.snapshot.updated'
     | 'wallet.connected'
     | 'wallet.disconnected'
-    | 'wallet.accountChanged'
-    | 'wallet.chainChanged'
-    | 'wallet.txSigned'
-    | 'wallet.error';
+    | 'wallet.account.changed'
+    | 'wallet.chain.changed';
   eventVersion: number;
   traceId: string;
   timestamp: string; // ISO-8601
@@ -92,7 +92,7 @@ export interface MfeEventEnvelope<TPayload = unknown> {
 ```ts
 export interface WalletConnectedPayload {
   account: string;
-  chainId: number;
+  chainId: number | null;
   connector?: string;
 }
 
@@ -156,6 +156,9 @@ Before merging contract changes:
 
 - Host starts and loads `mfe-wallets`.
 - Canonical events are emitted/consumed without runtime parsing errors.
+- `WalletsMfeMountApi.getSnapshot()` returns nullable `chainId` safely.
+- `WalletsMfeMountApi.syncConnectedWallet?.()` restores an already-linked
+  wallet when available and callers gracefully fall back when it is absent.
 - At least one backend-connected flow validates API envelope handling.
 - Error and fallback flows are verified (MFE unavailable or API failure).
 
@@ -178,9 +181,31 @@ Host files:
 - `src/app/domains/exchange/application/swap-execution.workflow.ts`
 - `src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts`
 
-Wallet MFE must expose `sendGatewayEvent` on `WalletsMfeMountApi` and `onIntentSigned` callback for the full flow to complete.
+Wallet MFE must expose `sendGatewayEvent` on `WalletsMfeMountApi` and
+`onIntentSigned` callback for the full flow to complete.
 
-## 7) Suggested file placement
+## 7) Connected Wallet Restore
+
+For linked-wallet profile flows, the host may request a best-effort restore of
+an already connected wallet before opening the wallet modal:
+
+```ts
+export type WalletsMfeMountApi = {
+  getSnapshot: () => WalletConnectionSnapshot;
+  syncConnectedWallet?: () => Promise<WalletConnectionSnapshot>;
+};
+
+export type WalletConnectionSnapshot = {
+  account: string | null;
+  chainId: number | null;
+};
+```
+
+`syncConnectedWallet` is optional for backward compatibility. If the mounted
+remote does not expose it, or if restore fails, the host should still open the
+wallet modal so the user can connect manually.
+
+## 8) Suggested file placement
 
 If/when extracting typed contracts into code, place them under:
 

--- a/src/app/mfe-contracts/wallet-mfe.types.ts
+++ b/src/app/mfe-contracts/wallet-mfe.types.ts
@@ -80,6 +80,7 @@ export type WalletsMfeMountApi = {
   getSnapshot: () => WalletConnectionSnapshot;
   sendGatewayEvent: (event: WalletGatewayEvent) => void;
   createEmbeddedWallet?: () => Promise<WalletOnboardingResult>;
+  syncConnectedWallet?: () => Promise<WalletConnectionSnapshot>;
   disconnectWallet?: () => void;
 };
 

--- a/src/app/pages/auth/generate-wallet/generate-wallet.component.spec.ts
+++ b/src/app/pages/auth/generate-wallet/generate-wallet.component.spec.ts
@@ -38,11 +38,9 @@ describe('GenerateWalletComponent', () => {
     authSession.ensureEmbeddedWallet.and.resolveTo();
     authSession.reloadWallets.and.resolveTo([]);
 
-    component = new GenerateWalletComponent(
-      authSession,
-      router,
-      { snapshot: { queryParamMap } } as never
-    );
+    component = new GenerateWalletComponent(authSession, router, {
+      snapshot: { queryParamMap },
+    } as never);
   });
 
   it('opens only the page-owned wallet connector modal', () => {
@@ -99,10 +97,8 @@ describe('GenerateWalletComponent', () => {
   });
 
   function createComponent(): GenerateWalletComponent {
-    return new GenerateWalletComponent(
-      authSession,
-      router,
-      { snapshot: { queryParamMap } } as never
-    );
+    return new GenerateWalletComponent(authSession, router, {
+      snapshot: { queryParamMap },
+    } as never);
   }
 });

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -125,10 +125,23 @@
         </button>
       </div>
       <div class="profile-shell__wallet-connect">
-        <p class="profile-shell__empty">
-          Connect a wallet to link or create one through the wallet modal.
-        </p>
-        <app-wallet-bar />
+        <ng-container *ngIf="hasLinkedWallets(); else connectWallet">
+          <button
+            type="button"
+            mat-button
+            color="primary"
+            class="profile-shell__view-wallet"
+            (click)="openWalletModal()">
+            View wallet
+            <span aria-hidden="true">›</span>
+          </button>
+        </ng-container>
+        <ng-template #connectWallet>
+          <p class="profile-shell__empty">
+            Connect a wallet to link or create one through the wallet modal.
+          </p>
+          <app-wallet-bar />
+        </ng-template>
       </div>
       <div
         class="profile-shell__empty"

--- a/src/app/pages/auth/profile/profile.component.spec.ts
+++ b/src/app/pages/auth/profile/profile.component.spec.ts
@@ -3,11 +3,15 @@
 import { BehaviorSubject, of } from 'rxjs';
 import { AuthSessionService } from '@core/auth/auth-session.service';
 import type { AuthSession } from '@core/auth/auth-session.types';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
 import { ProfileComponent } from './profile.component';
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
   let authSession: jasmine.SpyObj<AuthSessionService>;
+  let walletsService: jasmine.SpyObj<WalletsService>;
+  let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
   let sessionSubject: BehaviorSubject<AuthSession | null>;
 
   const enabledSession: AuthSession = {
@@ -28,6 +32,21 @@ describe('ProfileComponent', () => {
       passkeyEnabled: false,
     },
     wallets: [],
+  };
+
+  const linkedWalletSession: AuthSession = {
+    ...enabledSession,
+    wallets: [
+      {
+        id: 'wallet-1',
+        providerWalletId: 'provider-wallet-1',
+        address: '0x6e1a000000000000000000000000000000007690',
+        chainType: 'ethereum',
+        walletType: 'embedded',
+        source: 'provider',
+        isPrimary: true,
+      },
+    ],
   };
 
   beforeEach(() => {
@@ -52,8 +71,28 @@ describe('ProfileComponent', () => {
     );
     authSession.enablePasskey.and.resolveTo(enabledSession);
     authSession.loadBalances.and.resolveTo([]);
+    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
+      'requestOpen',
+    ]);
+    walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
+      'WalletGatewayBridgeService',
+      ['syncConnectedWallet']
+    );
+    walletGatewayBridge.syncConnectedWallet.and.resolveTo({
+      status: 'connected',
+      account: linkedWalletSession.wallets[0].address,
+      chainId: null,
+      isVerified: false,
+      safetyStatus: null,
+      isBypassed: false,
+      executionState: 'operating.idle',
+    });
 
-    component = new ProfileComponent(authSession);
+    component = new ProfileComponent(
+      authSession,
+      walletsService,
+      walletGatewayBridge
+    );
     component.ngOnInit();
   });
 
@@ -84,5 +123,30 @@ describe('ProfileComponent', () => {
 
     expect(component.isPasskeyLinked()).toBeTrue();
     expect(component.isPasskeyLoginAvailable()).toBeFalse();
+  });
+
+  it('treats linked backend wallets as connected for the wallet CTA', () => {
+    expect(component.hasLinkedWallets()).toBeFalse();
+
+    sessionSubject.next(linkedWalletSession);
+
+    expect(component.hasLinkedWallets()).toBeTrue();
+  });
+
+  it('syncs the connected wallet then opens the wallets MFE', async () => {
+    await component.openWalletModal();
+
+    expect(walletGatewayBridge.syncConnectedWallet).toHaveBeenCalledTimes(1);
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('still opens the wallets MFE when sync fails', async () => {
+    walletGatewayBridge.syncConnectedWallet.and.rejectWith(
+      new Error('gateway unavailable')
+    );
+
+    await component.openWalletModal();
+
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -6,6 +6,8 @@ import type {
   BackendBalance,
   BackendWallet,
 } from '@core/auth/auth-session.types';
+import { WalletsService } from '@shared/mfe/wallets/wallets.service';
+import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
 
 @Component({
   selector: 'app-profile',
@@ -27,7 +29,11 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
   private subscription?: Subscription;
 
-  constructor(public readonly authSession: AuthSessionService) {}
+  constructor(
+    public readonly authSession: AuthSessionService,
+    private readonly walletsService: WalletsService,
+    private readonly walletGatewayBridge: WalletGatewayBridgeService
+  ) {}
 
   public ngOnInit(): void {
     this.subscription = this.authSession.session$.subscribe(session => {
@@ -94,6 +100,19 @@ export class ProfileComponent implements OnInit, OnDestroy {
     } finally {
       this.passkeyLoading = false;
     }
+  }
+
+  public hasLinkedWallets(): boolean {
+    return (this.session?.wallets.length ?? 0) > 0;
+  }
+
+  public async openWalletModal(): Promise<void> {
+    try {
+      await this.walletGatewayBridge.syncConnectedWallet();
+    } catch {
+      // Still open the modal so the user can connect manually.
+    }
+    this.walletsService.requestOpen();
   }
 
   public async refreshWallets(): Promise<void> {

--- a/src/app/shared/components/side-modal/side-modal.component.scss
+++ b/src/app/shared/components/side-modal/side-modal.component.scss
@@ -1,4 +1,4 @@
-@import '@vodis/ui-kit/styles/breakpoints';
+@use '@vodis/cs-foundation/styles/breakpoints' as *;
 
 :host {
   .side-modal-backdrop {

--- a/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.spec.ts
+++ b/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.spec.ts
@@ -101,4 +101,33 @@ describe('WalletGatewayBridgeService', () => {
 
     expect(window.localStorage.getItem('mfe-wallets.session.v1')).toBeNull();
   });
+
+  it('returns the current snapshot when a wallet is already connected', async () => {
+    service.registerMountApi(mountApi);
+
+    await expectAsync(service.syncConnectedWallet()).toBeResolvedTo(
+      connectedSnapshot
+    );
+  });
+
+  it('delegates connected-wallet sync to the mounted wallet MFE', async () => {
+    const idleSnapshot: WalletConnectionSnapshot = {
+      ...connectedSnapshot,
+      status: 'idle',
+      account: null,
+      chainId: null,
+      isVerified: false,
+    };
+    (mountApi.getSnapshot as jasmine.Spy).and.returnValue(idleSnapshot);
+    const syncConnectedWallet = jasmine
+      .createSpy('syncConnectedWallet')
+      .and.resolveTo(connectedSnapshot);
+    mountApi.syncConnectedWallet = syncConnectedWallet;
+    service.registerMountApi(mountApi);
+
+    await expectAsync(service.syncConnectedWallet()).toBeResolvedTo(
+      connectedSnapshot
+    );
+    expect(syncConnectedWallet).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
+++ b/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
@@ -192,6 +192,26 @@ export class WalletGatewayBridgeService {
     return createEmbeddedWallet();
   }
 
+  async syncConnectedWallet(): Promise<WalletConnectionSnapshot> {
+    const snapshot = this.snapshotSubject.value ?? this.mountApi?.getSnapshot();
+    if (snapshot?.account) {
+      return snapshot;
+    }
+
+    const syncConnectedWallet = this.mountApi?.syncConnectedWallet;
+    if (!syncConnectedWallet) {
+      throw this.executionFailure(
+        'GATEWAY_UNAVAILABLE',
+        'Wallet connection sync is not available',
+        true
+      );
+    }
+
+    const nextSnapshot = await syncConnectedWallet();
+    this.snapshotSubject.next(nextSnapshot);
+    return nextSnapshot;
+  }
+
   private canSendGatewayEvent(): boolean {
     return typeof this.mountApi?.sendGatewayEvent === 'function';
   }

--- a/src/assets/manifest.json
+++ b/src/assets/manifest.json
@@ -1,16 +1,18 @@
 {
   "short_name": "CS",
   "name": "CraftScript",
-  "lange": "en",
+  "lang": "en",
   "description": "Yield more assets and earn profits in switching between strategies",
-  "start_url": "https://app.craftscript.com",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
   "dir": "ltr",
   "icons": [
     {
-      "src": "",
-      "size": "",
-      "type": "image/png",
-      "purpose": "maskable"
+      "src": "/assets/favicon.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon",
+      "purpose": "any"
     }
   ]
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,13 +1,14 @@
 // Angular Material 19: core + prebuilt theme (custom M2 theme requires internal APIs)
 @use '@angular/material' as mat;
+@use '@vodis/cs-foundation/styles/typography';
+@use '@vodis/cs-foundation/styles/utilities';
+@use '@vodis/cs-foundation/styles/grid';
+@use './assets/styles/mui-theme.css';
+@use './styles/exchange-page';
+@use './styles/register-page';
+@use './styles/profile-page';
 
 @include mat.core();
-
-/* You can add global styles to this file, and also import other style files */
-@import '@vodis/ui-kit/styles/typography';
-@import '@vodis/ui-kit/styles/utilities';
-@import '@vodis/ui-kit/styles/grid';
-@import './assets/styles/mui-theme.css';
 
 // Font imports
 @font-face {
@@ -77,10 +78,6 @@ button,
 a {
   cursor: pointer;
 }
-
-@import './styles/exchange-page';
-@import './styles/register-page';
-@import './styles/profile-page';
 
 .swap-form {
   --swap-radius: 10px;

--- a/src/styles/profile-page.scss
+++ b/src/styles/profile-page.scss
@@ -71,6 +71,17 @@
     margin: 0 0 1rem;
   }
 
+  &__view-wallet {
+    min-width: 0;
+    padding-left: 0;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+
+    span {
+      margin-left: 0.15rem;
+    }
+  }
+
   dl {
     display: grid;
     margin: 0;


### PR DESCRIPTION
## Summary
- promote the View wallet flow from `develop` to `master`
- show View wallet when the authenticated account already has linked wallets
- sync the wallet MFE gateway before opening the wallet modal so connected wallet state is restored
- vendor shell style tokens and add `BRANDING_BOOK.md` for layout/branding rules
- consume the published `@vodis/cs-foundation@0.2.0` package from GitHub Packages
- fix Module Federation public path and PWA manifest start URL for production compatibility
- align wallet MFE contract notes and host bridge tests

## Release Notes
- This PR is the production promotion of #147.
- CI installs `@vodis` packages from GitHub Packages with `GH_PACKAGES_TOKEN`.
- The production orchestrator bundle job is running on the latest `master` PR event; the push-only bundle job is skipped for PRs as configured.

## Verification
- TypeScript / ESLint: success
- Angular tests: success
- Shell layout E2E tests: success
- Production build: success
- `pr-checks` for the production workflow is currently running