### PR TITLE
feat(profile): reconnect last wallet after disconnect

### DIFF
--- a/src/app/core/auth/auth-session.service.spec.ts
+++ b/src/app/core/auth/auth-session.service.spec.ts
@@ -106,7 +106,7 @@ describe('AuthSessionService', () => {
     ]);
     productEvents = jasmine.createSpyObj<ProductEventsService>(
       'ProductEventsService',
-      ['record', 'reason', 'message']
+      ['record', 'recordFailure', 'reason', 'message']
     );
     productEvents.reason.and.returnValue('test_error');
     productEvents.message.and.callFake((error: unknown) =>

--- a/src/app/core/auth/auth-session.service.ts
+++ b/src/app/core/auth/auth-session.service.ts
@@ -128,11 +128,8 @@ export class AuthSessionService {
       });
       return session;
     } catch (error) {
-      this.productEvents.record({
-        eventName: 'auth.login',
-        status: 'failed',
-        reasonCode: this.productEvents.reason(error),
-        metadata: { authMethod, message: this.productEvents.message(error) },
+      this.productEvents.recordFailure('auth.login', error, {
+        metadata: { authMethod },
       });
       throw error;
     } finally {

--- a/src/app/core/product-events/product-events.service.spec.ts
+++ b/src/app/core/product-events/product-events.service.spec.ts
@@ -95,4 +95,51 @@ describe('ProductEventsService', () => {
 
     expect(warn).not.toHaveBeenCalled();
   });
+
+  it('recordFailure normalizes reasonCode and message', () => {
+    service.recordFailure(
+      'wallet.last_connected.persist',
+      new Error('Quota exceeded'),
+      {
+        metadata: {
+          action: 'set',
+          storage: 'sessionStorage',
+        },
+      }
+    );
+
+    const request = httpMock.expectOne(
+      `${environment.apiUrl}/api/v1/product-events`
+    );
+    expect(request.request.body).toEqual(
+      jasmine.objectContaining({
+        eventName: 'wallet.last_connected.persist',
+        status: 'failed',
+        reasonCode: 'quota_exceeded',
+        source: 'app-client',
+        metadata: jasmine.objectContaining({
+          action: 'set',
+          storage: 'sessionStorage',
+          message: 'Quota exceeded',
+        }),
+      })
+    );
+    request.flush({});
+  });
+
+  it('recordFailure uses unknown reason for non-Error values', () => {
+    service.recordFailure('wallet.last_connected.persist', 'boom');
+
+    const request = httpMock.expectOne(
+      `${environment.apiUrl}/api/v1/product-events`
+    );
+    expect(request.request.body).toEqual(
+      jasmine.objectContaining({
+        eventName: 'wallet.last_connected.persist',
+        status: 'failed',
+        reasonCode: 'unknown',
+      })
+    );
+    request.flush({});
+  });
 });

--- a/src/app/core/product-events/product-events.service.ts
+++ b/src/app/core/product-events/product-events.service.ts
@@ -14,6 +14,13 @@ type ProductEventInput = {
   metadata?: Record<string, unknown>;
 };
 
+type ProductEventContext = {
+  userId?: string;
+  sessionId?: string;
+  requestId?: string;
+  metadata?: Record<string, unknown>;
+};
+
 const ANONYMOUS_ID_KEY = 'cs_product_events_anonymous_id';
 
 @Injectable({ providedIn: 'root' })
@@ -38,6 +45,25 @@ export class ProductEventsService {
           }
         },
       });
+  }
+
+  recordFailure(
+    eventName: string,
+    error: unknown,
+    context: ProductEventContext = {}
+  ): void {
+    this.record({
+      eventName,
+      status: 'failed',
+      userId: context.userId,
+      sessionId: context.sessionId,
+      requestId: context.requestId,
+      reasonCode: this.reason(error),
+      metadata: {
+        message: this.message(error),
+        ...context.metadata,
+      },
+    });
   }
 
   reason(error: unknown): string {

--- a/src/app/core/routing/localized-routing.service.spec.ts
+++ b/src/app/core/routing/localized-routing.service.spec.ts
@@ -2,7 +2,9 @@ import {
   DEFAULT_LOCALE_SLUG,
   isLocaleSlug,
   languageToLocaleSlug,
+  localizedPath,
   localeSlugToLanguage,
+  LocalizedRoutingService,
   preferredLocalePath,
   preferredLocaleRedirect,
   stripLocalePrefix,
@@ -35,6 +37,33 @@ describe('localized routing helpers', () => {
     expect(stripLocalePrefix('/ua/farm')).toBe('/farm');
     expect(stripLocalePrefix('/pt/proposals')).toBe('/proposals');
     expect(stripLocalePrefix('/farm')).toBe('/farm');
+    expect(stripLocalePrefix('/en?ref=invite')).toBe('/?ref=invite');
+    expect(stripLocalePrefix('/pt#top')).toBe('/#top');
+    expect(stripLocalePrefix('/ua/farm?tab=owned#top')).toBe(
+      '/farm?tab=owned#top'
+    );
+  });
+
+  it('builds localized paths while preserving query strings and fragments', () => {
+    expect(localizedPath('/en?ref=invite', 'en')).toBe('/en?ref=invite');
+    expect(localizedPath('/pt#top', 'en')).toBe('/en#top');
+    expect(localizedPath('/ua/farm?tab=owned#top', 'pt')).toBe(
+      '/pt/farm?tab=owned#top'
+    );
+  });
+
+  it('reads the current locale from URLs with query strings and fragments', () => {
+    const router = { url: '/pt#top' };
+    const translations = { activeLanguage: 'EN' };
+    const service = new LocalizedRoutingService(
+      router as never,
+      translations as never
+    );
+
+    expect(service.currentLocale()).toBe('pt');
+
+    router.url = '/ua?ref=invite';
+    expect(service.currentLocale()).toBe('ua');
   });
 
   it('builds legacy redirects from stored language preference', () => {
@@ -43,5 +72,6 @@ describe('localized routing helpers', () => {
     expect(preferredLocaleRedirect()).toBe('/pt');
     expect(preferredLocalePath('/farm')).toBe('/pt/farm');
     expect(preferredLocalePath('/ua/proposals')).toBe('/pt/proposals');
+    expect(preferredLocalePath('/ua?ref=invite')).toBe('/pt?ref=invite');
   });
 });

--- a/src/app/core/routing/localized-routing.service.ts
+++ b/src/app/core/routing/localized-routing.service.ts
@@ -31,15 +31,44 @@ export function languageToLocaleSlug(language: string): LocaleSlug {
   return isLocaleSlug(locale) ? locale : DEFAULT_LOCALE_SLUG;
 }
 
-export function stripLocalePrefix(path: string): string {
+function splitPathSuffix(path: string): { pathname: string; suffix: string } {
   const cleanPath = path.startsWith('/') ? path : `/${path}`;
-  const [firstSegment, ...rest] = cleanPath.split('/').filter(Boolean);
+  const suffixIndex = cleanPath.search(/[?#]/);
 
-  if (!isLocaleSlug(firstSegment)) {
-    return cleanPath;
+  if (suffixIndex === -1) {
+    return { pathname: cleanPath, suffix: '' };
   }
 
-  return rest.length > 0 ? `/${rest.join('/')}` : '/';
+  return {
+    pathname: cleanPath.slice(0, suffixIndex) || '/',
+    suffix: cleanPath.slice(suffixIndex),
+  };
+}
+
+export function stripLocalePrefix(path: string): string {
+  const { pathname, suffix } = splitPathSuffix(path);
+  const [firstSegment, ...rest] = pathname.split('/').filter(Boolean);
+
+  if (!isLocaleSlug(firstSegment)) {
+    return `${pathname}${suffix}`;
+  }
+
+  const unprefixedPathname = rest.length > 0 ? `/${rest.join('/')}` : '/';
+  return `${unprefixedPathname}${suffix}`;
+}
+
+export function localizedPath(path: string, locale: LocaleSlug): string {
+  const unprefixedPath = stripLocalePrefix(path);
+
+  if (unprefixedPath === '/') {
+    return `/${locale}`;
+  }
+
+  if (unprefixedPath.startsWith('/?') || unprefixedPath.startsWith('/#')) {
+    return `/${locale}${unprefixedPath.slice(1)}`;
+  }
+
+  return `/${locale}${unprefixedPath}`;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -50,10 +79,8 @@ export class LocalizedRoutingService {
   ) {}
 
   public currentLocale(): LocaleSlug {
-    const [firstSegment] = this.router.url
-      .split('?')[0]
-      .split('/')
-      .filter(Boolean);
+    const { pathname } = splitPathSuffix(this.router.url);
+    const [firstSegment] = pathname.split('/').filter(Boolean);
 
     if (isLocaleSlug(firstSegment)) {
       return firstSegment;
@@ -63,10 +90,7 @@ export class LocalizedRoutingService {
   }
 
   public path(path: string, locale = this.currentLocale()): string {
-    const unprefixedPath = stripLocalePrefix(path);
-    return unprefixedPath === '/'
-      ? `/${locale}`
-      : `/${locale}${unprefixedPath}`;
+    return localizedPath(path, locale);
   }
 
   public navigateByUrl(path: string): Promise<boolean> {
@@ -104,16 +128,9 @@ export function preferredLocalePath(path: string): string {
   try {
     const storedLanguage = window.localStorage.getItem('active-language');
     const locale = languageToLocaleSlug(storedLanguage ?? '');
-    const unprefixedPath = stripLocalePrefix(path);
 
-    return unprefixedPath === '/'
-      ? `/${locale}`
-      : `/${locale}${unprefixedPath}`;
+    return localizedPath(path, locale);
   } catch {
-    const unprefixedPath = stripLocalePrefix(path);
-
-    return unprefixedPath === '/'
-      ? `/${DEFAULT_LOCALE_SLUG}`
-      : `/${DEFAULT_LOCALE_SLUG}${unprefixedPath}`;
+    return localizedPath(path, DEFAULT_LOCALE_SLUG);
   }
 }

--- a/src/app/domains/exchange/application/swap-execution.workflow.ts
+++ b/src/app/domains/exchange/application/swap-execution.workflow.ts
@@ -126,15 +126,11 @@ export class SwapExecutionWorkflow {
       this.logTransition(traceId, step, 'failed', Date.now() - startedAt, {
         error,
       });
-      this.productEvents.record({
-        eventName: 'swap.confirmed',
-        status: 'failed',
+      this.productEvents.recordFailure('swap.confirmed', error, {
         requestId: traceId,
-        reasonCode: this.productEvents.reason(error),
         metadata: {
           authMethod: request.authMethod,
           step,
-          message: this.productEvents.message(error),
           durationMs: Date.now() - startedAt,
         },
       });

--- a/src/app/domains/wallet/models/wallet.models.ts
+++ b/src/app/domains/wallet/models/wallet.models.ts
@@ -2,3 +2,11 @@ export interface WalletAccount {
   account: string;
   chainId: number | null;
 }
+
+export type LastConnectedWallet = {
+  account: string;
+  chainId: number | null;
+  walletType: 'embedded' | 'external';
+  source?: string;
+  connectorId?: string;
+};

--- a/src/app/mfe-contracts/wallet-mfe.types.ts
+++ b/src/app/mfe-contracts/wallet-mfe.types.ts
@@ -11,10 +11,27 @@ export type WalletConnectionStatus =
   | 'disconnected'
   | 'error';
 
+export type WalletConnectorId =
+  | 'metamask'
+  | 'walletconnect'
+  | 'coinbase'
+  | 'near'
+  | 'tonkeeper'
+  | 'privy';
+
+export type WalletIdentity = {
+  connectorId: WalletConnectorId;
+  address: string;
+  providerWalletId?: string;
+  chainType: 'ethereum' | 'near' | 'ton';
+  walletType: 'embedded' | 'external';
+};
+
 export type WalletConnectionSnapshot = {
   status: WalletConnectionStatus;
   account: string | null;
   chainId: number | null;
+  identity?: WalletIdentity | null;
   isVerified: boolean;
   safetyStatus: 'safe' | 'unsafe' | null;
   isBypassed: boolean;
@@ -37,7 +54,11 @@ export type WalletsMfeEvent =
     }
   | {
       type: 'wallet.connected';
-      payload: { account: string; chainId: number | null };
+      payload: {
+        account: string;
+        chainId: number | null;
+        identity?: WalletIdentity | null;
+      };
     }
   | { type: 'wallet.disconnected'; payload: { reason?: string } }
   | { type: 'wallet.account.changed'; payload: { account: string } }

--- a/src/app/pages/auth/profile/profile.component.html
+++ b/src/app/pages/auth/profile/profile.component.html
@@ -124,28 +124,109 @@
           Refresh
         </button>
       </div>
-      <div class="profile-shell__wallet-connect">
-        <ng-container *ngIf="hasLinkedWallets(); else connectWallet">
-          <button
-            type="button"
-            mat-button
-            color="primary"
-            class="profile-shell__view-wallet"
-            (click)="openWalletModal()">
-            View wallet
-            <span aria-hidden="true">›</span>
-          </button>
-        </ng-container>
-        <ng-template #connectWallet>
-          <p class="profile-shell__empty">
-            Connect a wallet to link or create one through the wallet modal.
-          </p>
-          <app-wallet-bar />
-        </ng-template>
+
+      <div class="profile-shell__wallet-connect" *ngIf="isLiveConnected()">
+        <div class="profile-shell__wallet-live">
+          <div class="profile-shell__wallet-live-main">
+            <span class="profile-shell__wallet-live-label">Connected</span>
+            <span class="profile-shell__wallet-live-address">{{
+              shortAddress(connectedAccount!)
+            }}</span>
+            <small *ngIf="resolveLastConnectedWallet() as liveMeta">{{
+              lastConnectedMeta(liveMeta)
+            }}</small>
+          </div>
+          <div class="profile-shell__wallet-live-actions">
+            <button
+              type="button"
+              mat-button
+              color="primary"
+              class="profile-shell__view-wallet"
+              [disabled]="walletActionBusy"
+              (click)="openWalletModal()">
+              View wallet
+              <span aria-hidden="true">›</span>
+            </button>
+            <button
+              type="button"
+              mat-stroked-button
+              [disabled]="walletActionBusy"
+              (click)="disconnectWallet()">
+              Disconnect
+            </button>
+          </div>
+        </div>
       </div>
+
+      <div
+        class="profile-shell__wallet-connect"
+        *ngIf="showLastConnectedSection()">
+        <div
+          class="profile-shell__last-wallet"
+          *ngIf="resolveLastConnectedWallet() as lastWallet">
+          <div class="profile-shell__last-wallet-copy">
+            <span class="profile-shell__last-wallet-label"
+              >Your last connected wallet</span
+            >
+            <span class="profile-shell__last-wallet-address">{{
+              shortAddress(lastWallet.account)
+            }}</span>
+            <small>{{ lastConnectedMeta(lastWallet) }}</small>
+          </div>
+          <div class="profile-shell__last-wallet-actions">
+            <button
+              type="button"
+              mat-flat-button
+              color="primary"
+              [disabled]="walletActionBusy"
+              (click)="reconnectWallet()">
+              Reconnect
+            </button>
+            <button
+              type="button"
+              mat-stroked-button
+              [disabled]="walletActionBusy"
+              (click)="connectAnotherWallet()">
+              Connect wallet
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="profile-shell__wallet-connect"
+        *ngIf="showEmptyConnectSection()">
+        <p class="profile-shell__empty">
+          Connect a wallet to link or create one through the wallet modal.
+        </p>
+        <app-wallet-bar />
+      </div>
+
+      <div
+        class="profile-shell__wallet-connect"
+        *ngIf="
+          !isLiveConnected() &&
+          !showLastConnectedSection() &&
+          hasLinkedWallets()
+        ">
+        <button
+          type="button"
+          mat-button
+          color="primary"
+          class="profile-shell__view-wallet"
+          (click)="openWalletModal()">
+          View wallet
+          <span aria-hidden="true">›</span>
+        </button>
+      </div>
+
       <div
         class="profile-shell__empty"
-        *ngIf="activeSession.wallets.length === 0">
+        *ngIf="
+          activeSession.wallets.length === 0 &&
+          !isLiveConnected() &&
+          !showLastConnectedSection()
+        ">
         No wallet linked yet.
       </div>
       <ul
@@ -160,6 +241,11 @@
             <span class="profile-shell__primary" *ngIf="wallet.isPrimary"
               >Active</span
             >
+            <span
+              class="profile-shell__wallet-locked"
+              *ngIf="isEmbeddedWallet(wallet)"
+              >Linked</span
+            >
             <button
               type="button"
               mat-button
@@ -171,6 +257,7 @@
             <button
               type="button"
               mat-button
+              *ngIf="canRemoveLinkedWallet(wallet)"
               [disabled]="busyWalletId === wallet.id"
               (click)="deleteWallet(wallet)">
               Remove

--- a/src/app/pages/auth/profile/profile.component.spec.ts
+++ b/src/app/pages/auth/profile/profile.component.spec.ts
@@ -3,6 +3,7 @@
 import { BehaviorSubject, of } from 'rxjs';
 import { AuthSessionService } from '@core/auth/auth-session.service';
 import type { AuthSession } from '@core/auth/auth-session.types';
+import { LastConnectedWallet } from '@domains/wallet/models/wallet.models';
 import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
 import { ProfileComponent } from './profile.component';
@@ -13,6 +14,10 @@ describe('ProfileComponent', () => {
   let walletsService: jasmine.SpyObj<WalletsService>;
   let walletGatewayBridge: jasmine.SpyObj<WalletGatewayBridgeService>;
   let sessionSubject: BehaviorSubject<AuthSession | null>;
+  let accountSubject: BehaviorSubject<
+    { account: string; chainId: number | null } | undefined
+  >;
+  let lastConnectedSubject: BehaviorSubject<LastConnectedWallet | undefined>;
 
   const enabledSession: AuthSession = {
     user: {
@@ -49,8 +54,29 @@ describe('ProfileComponent', () => {
     ],
   };
 
+  const externalWalletSession: AuthSession = {
+    ...enabledSession,
+    wallets: [
+      {
+        id: 'wallet-2',
+        providerWalletId: 'provider-wallet-2',
+        address: '0xabc000000000000000000000000000000000def0',
+        chainType: 'ethereum',
+        walletType: 'external',
+        source: 'metamask',
+        isPrimary: true,
+      },
+    ],
+  };
+
   beforeEach(() => {
     sessionSubject = new BehaviorSubject<AuthSession | null>(disabledSession);
+    accountSubject = new BehaviorSubject<
+      { account: string; chainId: number | null } | undefined
+    >(undefined);
+    lastConnectedSubject = new BehaviorSubject<LastConnectedWallet | undefined>(
+      undefined
+    );
     authSession = jasmine.createSpyObj<AuthSessionService>(
       'AuthSessionService',
       [
@@ -71,12 +97,17 @@ describe('ProfileComponent', () => {
     );
     authSession.enablePasskey.and.resolveTo(enabledSession);
     authSession.loadBalances.and.resolveTo([]);
-    walletsService = jasmine.createSpyObj<WalletsService>('WalletsService', [
-      'requestOpen',
-    ]);
+    walletsService = jasmine.createSpyObj<WalletsService>(
+      'WalletsService',
+      ['requestOpen', 'requestClose', 'setAccount', 'rememberConnectedWallet'],
+      {
+        account: accountSubject,
+        lastConnected: lastConnectedSubject,
+      }
+    );
     walletGatewayBridge = jasmine.createSpyObj<WalletGatewayBridgeService>(
       'WalletGatewayBridgeService',
-      ['syncConnectedWallet']
+      ['syncConnectedWallet', 'disconnectWallet']
     );
     walletGatewayBridge.syncConnectedWallet.and.resolveTo({
       status: 'connected',
@@ -148,5 +179,148 @@ describe('ProfileComponent', () => {
     await component.openWalletModal();
 
     expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects through the wallet gateway and remembers the last wallet', async () => {
+    accountSubject.next({
+      account: linkedWalletSession.wallets[0].address,
+      chainId: 1,
+    });
+    sessionSubject.next(linkedWalletSession);
+
+    await component.disconnectWallet();
+
+    expect(walletsService.rememberConnectedWallet).toHaveBeenCalled();
+    expect(walletGatewayBridge.disconnectWallet).toHaveBeenCalledTimes(1);
+    expect(walletsService.setAccount).toHaveBeenCalledOnceWith(undefined);
+    expect(walletsService.requestClose).toHaveBeenCalledTimes(1);
+    expect(component.walletMessage).toBe('Wallet disconnected');
+  });
+
+  it('shows a last-connected section after disconnect for embedded wallets', () => {
+    lastConnectedSubject.next({
+      account: linkedWalletSession.wallets[0].address,
+      chainId: null,
+      walletType: 'embedded',
+      source: 'privy',
+      connectorId: 'privy',
+    });
+
+    expect(component.showLastConnectedSection()).toBeTrue();
+    expect(
+      component.isEmbeddedWallet(component.resolveLastConnectedWallet())
+    ).toBeTrue();
+    expect(
+      component.canRemoveLinkedWallet(linkedWalletSession.wallets[0])
+    ).toBeFalse();
+  });
+
+  it('allows connect wallet and remove for external wallets', () => {
+    sessionSubject.next(externalWalletSession);
+    lastConnectedSubject.next({
+      account: externalWalletSession.wallets[0].address,
+      chainId: null,
+      walletType: 'external',
+      source: 'metamask',
+      connectorId: 'metamask',
+    });
+
+    expect(component.showLastConnectedSection()).toBeTrue();
+    expect(
+      component.isEmbeddedWallet(component.resolveLastConnectedWallet())
+    ).toBeFalse();
+    expect(
+      component.canRemoveLinkedWallet(externalWalletSession.wallets[0])
+    ).toBeTrue();
+  });
+
+  it('reconnects by syncing without opening the wallets MFE', async () => {
+    await component.reconnectWallet();
+
+    expect(walletGatewayBridge.syncConnectedWallet).toHaveBeenCalledTimes(1);
+    expect(walletsService.setAccount).toHaveBeenCalled();
+    expect(walletsService.rememberConnectedWallet).toHaveBeenCalled();
+    expect(walletsService.requestOpen).not.toHaveBeenCalled();
+    expect(component.walletMessage).toBe('Wallet reconnected');
+  });
+
+  it('opens the wallets MFE when reconnect sync returns no account', async () => {
+    walletGatewayBridge.syncConnectedWallet.and.resolveTo({
+      status: 'disconnected',
+      account: null,
+      chainId: null,
+      isVerified: false,
+      safetyStatus: null,
+      isBypassed: false,
+      executionState: 'operating.idle',
+    });
+
+    await component.reconnectWallet();
+
+    expect(walletsService.setAccount).not.toHaveBeenCalled();
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the wallets MFE and sets an error when reconnect sync fails', async () => {
+    walletGatewayBridge.syncConnectedWallet.and.rejectWith(
+      new Error('gateway unavailable')
+    );
+
+    await component.reconnectWallet();
+
+    expect(component.error).toBe('gateway unavailable');
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the wallets MFE without sync when connecting another wallet', () => {
+    component.connectAnotherWallet();
+
+    expect(walletGatewayBridge.syncConnectedWallet).not.toHaveBeenCalled();
+    expect(walletsService.requestOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks removing embedded wallets', async () => {
+    sessionSubject.next(linkedWalletSession);
+
+    await component.deleteWallet(linkedWalletSession.wallets[0]);
+
+    expect(authSession.deleteWallet).not.toHaveBeenCalled();
+    expect(component.error).toContain('cannot be removed');
+  });
+
+  it('seeds last connected from primary linked wallet', () => {
+    sessionSubject.next(linkedWalletSession);
+
+    expect(walletsService.rememberConnectedWallet).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        account: linkedWalletSession.wallets[0].address,
+        walletType: 'embedded',
+      })
+    );
+    expect(component.showLastConnectedSection()).toBeTrue();
+  });
+
+  it('shows empty connect section only when there is no wallet history', () => {
+    expect(component.showEmptyConnectSection()).toBeTrue();
+
+    lastConnectedSubject.next({
+      account: linkedWalletSession.wallets[0].address,
+      chainId: null,
+      walletType: 'embedded',
+    });
+
+    expect(component.showEmptyConnectSection()).toBeFalse();
+  });
+
+  it('treats a live account as connected', () => {
+    expect(component.isLiveConnected()).toBeFalse();
+
+    accountSubject.next({
+      account: linkedWalletSession.wallets[0].address,
+      chainId: 1,
+    });
+
+    expect(component.isLiveConnected()).toBeTrue();
+    expect(component.showLastConnectedSection()).toBeFalse();
   });
 });

--- a/src/app/pages/auth/profile/profile.component.ts
+++ b/src/app/pages/auth/profile/profile.component.ts
@@ -6,6 +6,7 @@ import type {
   BackendBalance,
   BackendWallet,
 } from '@core/auth/auth-session.types';
+import { LastConnectedWallet } from '@domains/wallet/models/wallet.models';
 import { WalletsService } from '@shared/mfe/wallets/wallets.service';
 import { WalletGatewayBridgeService } from '@shared/mfe/wallets/wallet-gateway.bridge.service';
 
@@ -26,6 +27,9 @@ export class ProfileComponent implements OnInit, OnDestroy {
   public passkeyLoading = false;
   public balances: BackendBalance[] = [];
   public balancesLoading = false;
+  public connectedAccount: string | null = null;
+  public lastConnectedWallet: LastConnectedWallet | null = null;
+  public walletActionBusy = false;
 
   private subscription?: Subscription;
 
@@ -36,14 +40,28 @@ export class ProfileComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
-    this.subscription = this.authSession.session$.subscribe(session => {
-      this.session = session;
-      if (session) {
-        void this.refreshBalances();
-      } else {
-        this.balances = [];
-      }
-    });
+    this.subscription = new Subscription();
+    this.subscription.add(
+      this.authSession.session$.subscribe(session => {
+        this.session = session;
+        if (session) {
+          this.seedLastConnectedFromBackend(session.wallets);
+          void this.refreshBalances();
+        } else {
+          this.balances = [];
+        }
+      })
+    );
+    this.subscription.add(
+      this.walletsService.account.subscribe(account => {
+        this.connectedAccount = account?.account ?? null;
+      })
+    );
+    this.subscription.add(
+      this.walletsService.lastConnected.subscribe(wallet => {
+        this.lastConnectedWallet = wallet ?? null;
+      })
+    );
   }
 
   public ngOnDestroy(): void {
@@ -58,6 +76,14 @@ export class ProfileComponent implements OnInit, OnDestroy {
     return [wallet.chainType, wallet.walletType, wallet.source]
       .filter(Boolean)
       .join(' / ');
+  }
+
+  public lastConnectedMeta(wallet: LastConnectedWallet): string {
+    const parts = [
+      wallet.walletType === 'embedded' ? 'embedded' : 'external',
+      wallet.connectorId || wallet.source,
+    ].filter(Boolean);
+    return parts.join(' / ');
   }
 
   public balanceAmount(balance: BackendBalance): string {
@@ -106,12 +132,135 @@ export class ProfileComponent implements OnInit, OnDestroy {
     return (this.session?.wallets.length ?? 0) > 0;
   }
 
+  public isLiveConnected(): boolean {
+    return Boolean(this.connectedAccount);
+  }
+
+  public showLastConnectedSection(): boolean {
+    return (
+      !this.isLiveConnected() && Boolean(this.resolveLastConnectedWallet())
+    );
+  }
+
+  public showEmptyConnectSection(): boolean {
+    return (
+      !this.isLiveConnected() &&
+      !this.showLastConnectedSection() &&
+      !this.hasLinkedWallets()
+    );
+  }
+
+  public resolveLastConnectedWallet(): LastConnectedWallet | null {
+    if (this.lastConnectedWallet) {
+      return this.lastConnectedWallet;
+    }
+
+    const linked = this.primaryLinkedWallet();
+    if (!linked) {
+      return null;
+    }
+
+    return this.toLastConnected(linked);
+  }
+
+  public isEmbeddedWallet(
+    wallet: LastConnectedWallet | BackendWallet | null | undefined
+  ): boolean {
+    if (!wallet) {
+      return false;
+    }
+
+    if ('walletType' in wallet) {
+      return String(wallet.walletType).toLowerCase() === 'embedded';
+    }
+
+    return false;
+  }
+
+  public canRemoveLinkedWallet(wallet: BackendWallet): boolean {
+    return !this.isEmbeddedWallet(wallet);
+  }
+
   public async openWalletModal(): Promise<void> {
     try {
       await this.walletGatewayBridge.syncConnectedWallet();
-    } catch {
-      // Still open the modal so the user can connect manually.
+    } catch {}
+    this.walletsService.requestOpen();
+  }
+
+  public async disconnectWallet(): Promise<void> {
+    this.error = '';
+    this.walletMessage = '';
+    this.walletActionBusy = true;
+    try {
+      const current = this.connectedAccount;
+      if (current) {
+        const linked = this.findLinkedWallet(current);
+        this.walletsService.rememberConnectedWallet(
+          linked
+            ? this.toLastConnected(linked)
+            : {
+                account: current,
+                chainId: this.walletsService.account.value?.chainId ?? null,
+                walletType: this.lastConnectedWallet?.walletType ?? 'external',
+                source: this.lastConnectedWallet?.source,
+                connectorId: this.lastConnectedWallet?.connectorId,
+              }
+        );
+      }
+      this.walletGatewayBridge.disconnectWallet();
+      this.walletsService.setAccount(undefined);
+      this.walletsService.requestClose();
+      this.walletMessage = 'Wallet disconnected';
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Wallet disconnect failed';
+    } finally {
+      this.walletActionBusy = false;
     }
+  }
+
+  public async reconnectWallet(): Promise<void> {
+    this.error = '';
+    this.walletMessage = '';
+    this.walletActionBusy = true;
+    try {
+      const snapshot = await this.walletGatewayBridge.syncConnectedWallet();
+      if (snapshot.account) {
+        this.walletsService.setAccount({
+          account: snapshot.account,
+          chainId: snapshot.chainId,
+        });
+        this.walletsService.rememberConnectedWallet({
+          account: snapshot.account,
+          chainId: snapshot.chainId,
+          walletType:
+            snapshot.identity?.walletType ??
+            this.lastConnectedWallet?.walletType ??
+            'external',
+          source:
+            snapshot.identity?.connectorId ?? this.lastConnectedWallet?.source,
+          connectorId:
+            snapshot.identity?.connectorId ??
+            this.lastConnectedWallet?.connectorId,
+        });
+        this.walletMessage = 'Wallet reconnected';
+        return;
+      }
+
+      this.walletsService.requestOpen();
+    } catch (error) {
+      this.error =
+        error instanceof Error ? error.message : 'Wallet reconnect failed';
+      this.walletsService.requestOpen();
+    } finally {
+      this.walletActionBusy = false;
+    }
+  }
+
+  public connectAnotherWallet(): void {
+    this.error = '';
+    this.walletMessage = '';
     this.walletsService.requestOpen();
   }
 
@@ -163,6 +312,12 @@ export class ProfileComponent implements OnInit, OnDestroy {
   }
 
   public async deleteWallet(wallet: BackendWallet): Promise<void> {
+    if (!this.canRemoveLinkedWallet(wallet)) {
+      this.error =
+        'Embedded wallets stay linked to your account and cannot be removed.';
+      return;
+    }
+
     this.error = '';
     this.walletMessage = '';
     this.busyWalletId = wallet.id;
@@ -200,6 +355,42 @@ export class ProfileComponent implements OnInit, OnDestroy {
     } catch (error) {
       this.error = error instanceof Error ? error.message : 'Logout failed';
     }
+  }
+
+  private seedLastConnectedFromBackend(wallets: BackendWallet[]): void {
+    if (this.lastConnectedWallet || wallets.length === 0) {
+      return;
+    }
+
+    const linked = this.primaryLinkedWallet(wallets);
+    if (linked) {
+      this.walletsService.rememberConnectedWallet(this.toLastConnected(linked));
+    }
+  }
+
+  private primaryLinkedWallet(
+    wallets: BackendWallet[] = this.session?.wallets ?? []
+  ): BackendWallet | undefined {
+    return wallets.find(wallet => wallet.isPrimary) ?? wallets[0];
+  }
+
+  private findLinkedWallet(address: string): BackendWallet | undefined {
+    const normalized = address.toLowerCase();
+    return this.session?.wallets.find(
+      wallet => wallet.address.toLowerCase() === normalized
+    );
+  }
+
+  private toLastConnected(wallet: BackendWallet): LastConnectedWallet {
+    return {
+      account: wallet.address,
+      chainId: null,
+      walletType:
+        String(wallet.walletType).toLowerCase() === 'embedded'
+          ? 'embedded'
+          : 'external',
+      source: wallet.source,
+    };
   }
 
   private rawToDecimal(rawBalance: string, decimals: number): string {

--- a/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
+++ b/src/app/shared/mfe/wallets/wallet-gateway.bridge.service.ts
@@ -27,6 +27,7 @@ const DISCONNECTED_SNAPSHOT: WalletConnectionSnapshot = {
   status: 'disconnected',
   account: null,
   chainId: null,
+  identity: null,
   isVerified: false,
   safetyStatus: null,
   isBypassed: false,

--- a/src/app/shared/mfe/wallets/wallets.component.ts
+++ b/src/app/shared/mfe/wallets/wallets.component.ts
@@ -96,6 +96,16 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
                 account: account.account,
                 chainId: this.walletsService.account.value?.chainId ?? null,
               });
+              this.walletsService.rememberConnectedWallet({
+                account: account.account,
+                chainId: this.walletsService.account.value?.chainId ?? null,
+                walletType:
+                  this.walletsService.lastConnected.value?.walletType ??
+                  'external',
+                source: this.walletsService.lastConnected.value?.source,
+                connectorId:
+                  this.walletsService.lastConnected.value?.connectorId,
+              });
               this.refreshBackendWallets();
             });
           },
@@ -156,6 +166,13 @@ export class WalletsComponent implements AfterViewInit, OnDestroy {
       this.walletsService.setAccount({
         account: snapshot.account,
         chainId: snapshot.chainId,
+      });
+      this.walletsService.rememberConnectedWallet({
+        account: snapshot.account,
+        chainId: snapshot.chainId,
+        walletType: snapshot.identity?.walletType ?? 'external',
+        source: snapshot.identity?.connectorId,
+        connectorId: snapshot.identity?.connectorId,
       });
       this.refreshBackendWallets();
       return;

--- a/src/app/shared/mfe/wallets/wallets.service.spec.ts
+++ b/src/app/shared/mfe/wallets/wallets.service.spec.ts
@@ -1,0 +1,146 @@
+/// <reference types="jasmine" />
+
+import { TestBed } from '@angular/core/testing';
+import { ProductEventsService } from '@core/product-events/product-events.service';
+import { LastConnectedWallet } from '@domains/wallet/models/wallet.models';
+import { WalletsService } from './wallets.service';
+
+describe('WalletsService', () => {
+  let service: WalletsService;
+  let productEvents: jasmine.SpyObj<ProductEventsService>;
+  const storageKey = 'cs-host.last-connected-wallet.v1';
+
+  const wallet: LastConnectedWallet = {
+    account: '0x6e1a000000000000000000000000000000007690',
+    chainId: 1,
+    walletType: 'embedded',
+    source: 'privy',
+    connectorId: 'privy',
+  };
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    productEvents = jasmine.createSpyObj<ProductEventsService>(
+      'ProductEventsService',
+      ['recordFailure']
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        WalletsService,
+        { provide: ProductEventsService, useValue: productEvents },
+      ],
+    });
+
+    service = TestBed.inject(WalletsService);
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('persists and restores the last connected wallet', () => {
+    service.rememberConnectedWallet(wallet);
+
+    expect(service.lastConnected.value).toEqual(wallet);
+    expect(
+      JSON.parse(window.sessionStorage.getItem(storageKey) ?? '{}')
+    ).toEqual(wallet);
+  });
+
+  it('hydrates lastConnected from sessionStorage on construction', () => {
+    window.sessionStorage.setItem(storageKey, JSON.stringify(wallet));
+
+    const fresh = new WalletsService(productEvents);
+
+    expect(fresh.lastConnected.value).toEqual(wallet);
+  });
+
+  it('ignores invalid sessionStorage payloads when hydrating', () => {
+    window.sessionStorage.setItem(storageKey, '{not-json');
+    const fresh = new WalletsService(productEvents);
+    expect(fresh.lastConnected.value).toBeUndefined();
+  });
+
+  it('clears last connected wallet from memory and storage', () => {
+    service.rememberConnectedWallet(wallet);
+    service.clearLastConnectedWallet();
+
+    expect(service.lastConnected.value).toBeUndefined();
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it('records a product event when persist fails', () => {
+    spyOn(window.sessionStorage, 'setItem').and.throwError(
+      'QuotaExceededError'
+    );
+
+    service.rememberConnectedWallet(wallet);
+
+    expect(service.lastConnected.value).toEqual(wallet);
+    expect(productEvents.recordFailure).toHaveBeenCalledOnceWith(
+      'wallet.last_connected.persist',
+      jasmine.any(Error),
+      {
+        metadata: {
+          action: 'set',
+          storage: 'sessionStorage',
+          walletType: 'embedded',
+          connectorId: 'privy',
+        },
+      }
+    );
+  });
+
+  it('records a product event when clear fails', () => {
+    service.rememberConnectedWallet(wallet);
+    spyOn(window.sessionStorage, 'removeItem').and.throwError(
+      'storage blocked'
+    );
+
+    service.clearLastConnectedWallet();
+
+    expect(service.lastConnected.value).toBeUndefined();
+    expect(productEvents.recordFailure).toHaveBeenCalledOnceWith(
+      'wallet.last_connected.persist',
+      jasmine.any(Error),
+      {
+        metadata: {
+          action: 'clear',
+          storage: 'sessionStorage',
+        },
+      }
+    );
+  });
+
+  it('defaults unknown walletType values to external when hydrating', () => {
+    window.sessionStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        account: wallet.account,
+        chainId: null,
+        walletType: 'something-else',
+      })
+    );
+
+    const fresh = new WalletsService(productEvents);
+    expect(fresh.lastConnected.value).toEqual(
+      jasmine.objectContaining({
+        account: wallet.account,
+        walletType: 'external',
+      })
+    );
+  });
+
+  it('manages open and close request flags', () => {
+    service.requestOpen();
+    expect(service.openRequested.value).toBeTrue();
+    service.clearOpenRequest();
+    expect(service.openRequested.value).toBeFalse();
+
+    service.requestClose();
+    expect(service.closeRequested.value).toBeTrue();
+    service.clearCloseRequest();
+    expect(service.closeRequested.value).toBeFalse();
+  });
+});

--- a/src/app/shared/mfe/wallets/wallets.service.ts
+++ b/src/app/shared/mfe/wallets/wallets.service.ts
@@ -1,6 +1,68 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { WalletAccount } from '@domains/wallet/models/wallet.models';
+import {
+  LastConnectedWallet,
+  WalletAccount,
+} from '@domains/wallet/models/wallet.models';
+import { ProductEventsService } from '@core/product-events/product-events.service';
+
+const LAST_CONNECTED_STORAGE_KEY = 'cs-host.last-connected-wallet.v1';
+
+function isWalletType(
+  value: unknown
+): value is LastConnectedWallet['walletType'] {
+  return value === 'embedded' || value === 'external';
+}
+
+function parseLastConnected(
+  raw: string | null
+): LastConnectedWallet | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('account' in parsed) ||
+      typeof (parsed as { account: unknown }).account !== 'string'
+    ) {
+      return undefined;
+    }
+
+    const account = (parsed as { account: string }).account;
+    if (!account) {
+      return undefined;
+    }
+
+    const chainIdValue = (parsed as { chainId?: unknown }).chainId;
+    const chainId =
+      typeof chainIdValue === 'number'
+        ? chainIdValue
+        : chainIdValue === null
+          ? null
+          : null;
+    const walletTypeValue = (parsed as { walletType?: unknown }).walletType;
+    const walletType = isWalletType(walletTypeValue)
+      ? walletTypeValue
+      : 'external';
+    const sourceValue = (parsed as { source?: unknown }).source;
+    const connectorIdValue = (parsed as { connectorId?: unknown }).connectorId;
+
+    return {
+      account,
+      chainId,
+      walletType,
+      source: typeof sourceValue === 'string' ? sourceValue : undefined,
+      connectorId:
+        typeof connectorIdValue === 'string' ? connectorIdValue : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 @Injectable({
   providedIn: 'root',
@@ -8,11 +70,53 @@ import { WalletAccount } from '@domains/wallet/models/wallet.models';
 export class WalletsService {
   public provider = new BehaviorSubject<unknown | undefined>(undefined);
   public account = new BehaviorSubject<WalletAccount | undefined>(undefined);
+  public lastConnected = new BehaviorSubject<LastConnectedWallet | undefined>(
+    parseLastConnected(
+      typeof window !== 'undefined'
+        ? window.sessionStorage.getItem(LAST_CONNECTED_STORAGE_KEY)
+        : null
+    )
+  );
   public closeRequested = new BehaviorSubject<boolean>(false);
   public openRequested = new BehaviorSubject<boolean>(false);
 
+  constructor(private readonly productEvents: ProductEventsService) {}
+
   setAccount(account: WalletAccount | undefined): void {
     this.account.next(account);
+  }
+
+  rememberConnectedWallet(wallet: LastConnectedWallet): void {
+    this.lastConnected.next(wallet);
+    try {
+      window.sessionStorage.setItem(
+        LAST_CONNECTED_STORAGE_KEY,
+        JSON.stringify(wallet)
+      );
+    } catch (error) {
+      this.productEvents.recordFailure('wallet.last_connected.persist', error, {
+        metadata: {
+          action: 'set',
+          storage: 'sessionStorage',
+          walletType: wallet.walletType,
+          connectorId: wallet.connectorId,
+        },
+      });
+    }
+  }
+
+  clearLastConnectedWallet(): void {
+    this.lastConnected.next(undefined);
+    try {
+      window.sessionStorage.removeItem(LAST_CONNECTED_STORAGE_KEY);
+    } catch (error) {
+      this.productEvents.recordFailure('wallet.last_connected.persist', error, {
+        metadata: {
+          action: 'clear',
+          storage: 'sessionStorage',
+        },
+      });
+    }
   }
 
   requestClose(): void {

--- a/src/styles/profile-page.scss
+++ b/src/styles/profile-page.scss
@@ -71,6 +71,57 @@
     margin: 0 0 1rem;
   }
 
+  &__wallet-live,
+  &__last-wallet {
+    display: grid;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgb(255 255 255 / 12%);
+    border-radius: 8px;
+    background: rgb(255 255 255 / 4%);
+    gap: 0.85rem;
+  }
+
+  &__wallet-live-main,
+  &__last-wallet-copy {
+    display: grid;
+    min-width: 0;
+    gap: 0.2rem;
+  }
+
+  &__wallet-live-label,
+  &__last-wallet-label {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
+  &__wallet-live-label {
+    color: var(--success, #7ee787);
+  }
+
+  &__wallet-live-address,
+  &__last-wallet-address {
+    color: var(--gray-30);
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+  }
+
+  &__wallet-live-actions,
+  &__last-wallet-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.65rem;
+  }
+
+  &__wallet-locked {
+    color: var(--secondary-text-color);
+    font-size: 0.78rem;
+    line-height: 1rem;
+  }
+
   &__view-wallet {
     min-width: 0;
     padding-left: 0;
@@ -275,7 +326,9 @@
       gap: 0.15rem;
     }
 
-    &__wallet-actions {
+    &__wallet-actions,
+    &__wallet-live-actions,
+    &__last-wallet-actions {
       justify-content: flex-start;
     }
 


### PR DESCRIPTION
Keep last-connected wallet on Profile with Reconnect / Connect wallet, and add product-events recordFailure for shared failure telemetry.